### PR TITLE
Remove Unused Logger in Map Checker

### DIFF
--- a/src/plugins/MapChecker.ts
+++ b/src/plugins/MapChecker.ts
@@ -98,7 +98,7 @@ export class DefaultValidator extends ValidatorBase {
     let r = 0;
 
     let rs = { rate: r, message: "" };
-    this.logger.info(map.difficulty_rating);
+
     if (map.mode != this.gamemode && this.gamemode != "") {
       r += 1;
     }
@@ -398,7 +398,7 @@ export class MapChecker extends LobbyPlugin {
       this.logger.info(`target map is changed. checked:${mapId}, current:${this.checkingMapId}`);
       return;
     }
-    this.logger.info(this.validator.GetGameMode());
+
     let r = this.validator.RateBeatmap(map);
     if (0 < r.rate) {
       this.numViolations += 1;


### PR DESCRIPTION
I'm sorry I forgot to remove the logger that I used to debug get current game mode and map star rating. It's unused now.