### PR TITLE
Bug Fix `!mirror` Command in MiscLoader and Deprecate `ProfileRepository` in favour of `WebApiClient`

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,7 @@
     "gamemode": "osu",
     "num_violations_allowed": 3,
     "allow_convert": true,
-    "map_description": "[https://osu.ppy.sh/b/${map_id} ${title}] | Star Rating: ${star} | Duration: ${length} | Alternative:  [https://beatconnect.io/b/${beatmapset_id} (Beatconnect)] | [https://api.chimu.moe/v1/download/${beatmapset_id}?n=1 (Chimu)]"
+    "map_description": "[https://osu.ppy.sh/b/${map_id} ${title}] | Star Rating: ${star} | Duration: ${length} | Alternative:  [https://beatconnect.io/b/${beatmapset_id} (BeatConnect.io)] | [https://kitsu.moe/d/${beatmapset_id} (Kitsu.moe)]"
   },
   "MiscLoader": {},
   "MapRecaster": {},

--- a/config/default.json
+++ b/config/default.json
@@ -65,7 +65,7 @@
     "gamemode": "osu",
     "num_violations_allowed": 3,
     "allow_convert": true,
-    "map_description": "[https://osu.ppy.sh/b/${map_id} ${title}] star=${star} len=${length} - [https://beatconnect.io/b/${beatmapset_id} Alternative(beatconnect.io)]"
+    "map_description": "[https://osu.ppy.sh/b/${map_id} ${title}] | Star Rating: ${star} | Duration: ${length} | Alternative:  [https://beatconnect.io/b/${beatmapset_id} (Beatconnect)] | [https://api.chimu.moe/v1/download/${beatmapset_id}?n=1 (Chimu)]"
   },
   "MiscLoader": {},
   "MapRecaster": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osu-ahr",
-  "version": "1.5.10",
+  "version": "1.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "osu-ahr",
-      "version": "1.5.10",
+      "version": "1.5.14",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osu-ahr",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "irc bot for osu! multi lobby auto host rotation.",
   "main": "dist/cli/index.js",
   "homepage": "https://github.com/Meowhal/osu-ahr",

--- a/src/plugins/MapChecker.ts
+++ b/src/plugins/MapChecker.ts
@@ -210,8 +210,8 @@ export class MapChecker extends LobbyPlugin {
             this.rejectMap(`[https://osu.ppy.sh/b/${mapId} ${mapTitle}] had already been removed from the website.`, false);
             break;
           case FetchBeatmapErrorReason.PlayModeMismatched:
-            this.logger.info(`Gamemode Mismatched. checked:${mapId}`);
-            this.rejectMap(`Gamemode Mismatched. Pick ${this.option.gamemode.officialName} map.`, false);
+            this.logger.info(`Gamemode mismatched. checked:${mapId}`);
+            this.rejectMap(`[https://osu.ppy.sh/b/${mapId} ${mapTitle}] is not ${this.option.gamemode.officialName} map. Pick ${this.option.gamemode.officialName} map.`, false);
             break;
           case FetchBeatmapErrorReason.NotAvailable:
             this.logger.info(`Map is not available. checked:${mapId}`);
@@ -236,7 +236,7 @@ export class MapChecker extends LobbyPlugin {
     this.logger.info(`Rejected the map selected by ${this.lobby.host?.escaped_name} (${this.numViolations} / ${this.option.num_violations_allowed})`);
 
     if (showRegulation) {
-      this.lobby.SendMessage(`!mp map ${this.lastMapId} ${this.option.gamemode.value} | Current Regulation : ${this.validator.GetDescription()}`);
+      this.lobby.SendMessage(`!mp map ${this.lastMapId} ${this.option.gamemode.value} | Current Regulation: ${this.validator.GetDescription()}`);
       this.lobby.SendMessage(reason);
       this.lobby.SendMessage("*Attention! Difficulty will not be calculated correctly if a global mod is applied.");
     } else {

--- a/src/plugins/MapChecker.ts
+++ b/src/plugins/MapChecker.ts
@@ -324,7 +324,7 @@ export class MapValidator {
 
     if (0 < rate) {
       let message;
-      const mapDesc = `The [${map.url} ${map.beatmapset?.title}] (star=${map.difficulty_rating} len=${secToTimeNotation(map.total_length)})`
+      const mapDesc = `[${map.url} ${map.beatmapset?.title}] (Star Rating: ${map.difficulty_rating} Duration: ${secToTimeNotation(map.total_length)})`
       if (violationMsgs.length == 1) {
         message = `${mapDesc} was rejected because ${violationMsgs[0]}`;
       } else {

--- a/src/plugins/MiscLoader.ts
+++ b/src/plugins/MiscLoader.ts
@@ -17,7 +17,7 @@ export class MiscLoader extends LobbyPlugin {
   option: MiscLoaderOption;
   canResend: boolean = true;
   beatconnectURL: string = "https://beatconnect.io/b/${beatmapset_id}";
-  chimuURL: string = "https://api.chimu.moe/v1/download/${beatmapset_id}?n=1";
+  kitsuURL: string = "https://kitsu.moe/d/${beatmapset_id}";
   canSeeRank: boolean = false;
 
   constructor(lobby: Lobby, option: Partial<MiscLoaderOption> = {}) {
@@ -109,9 +109,9 @@ export class MiscLoader extends LobbyPlugin {
       }
       this.canResend = true;
       var beatconnectLink = this.beatconnectURL.replace(/\$\{beatmapset_id\}/g, map.beatmapset_id.toString());
-      var chimuLink = this.chimuURL.replace(/\$\{beatmapset_id\}/g, map.beatmapset_id.toString());
+      var kitsuLink = this.kitsuURL.replace(/\$\{beatmapset_id\}/g, map.beatmapset_id.toString());
       var beatmapView = map.beatmapset?.title.toString();
-      this.lobby.SendMessageWithCoolTime(`Alternative download link for ${beatmapView} : [${beatconnectLink} Beatconnect] | [${chimuLink} Chimu]`, "!mirror", 5000);
+      this.lobby.SendMessageWithCoolTime(`Alternative download link for ${beatmapView} : [${beatconnectLink} BeatConnect.io] | [${kitsuLink} Kitsu.moe]`, "!mirror", 5000);
     } catch (e: any) {
       this.canResend = false;
       if (e instanceof FetchBeatmapError) {

--- a/src/plugins/MiscLoader.ts
+++ b/src/plugins/MiscLoader.ts
@@ -16,7 +16,8 @@ export interface MiscLoaderOption {
 export class MiscLoader extends LobbyPlugin {
   option: MiscLoaderOption;
   canResend: boolean = true;
-  rootURL: string = "https://beatconnect.io/b/";
+  beatconnectURL: string = "https://beatconnect.io/b/${beatmapset_id}";
+  chimuURL: string = "https://api.chimu.moe/v1/download/${beatmapset_id}?n=1";
   canSeeRank: boolean = false;
 
   constructor(lobby: Lobby, option: Partial<MiscLoaderOption> = {}) {
@@ -107,8 +108,10 @@ export class MiscLoader extends LobbyPlugin {
         return;
       }
       this.canResend = true;
-      var downloadLink = this.rootURL + map.beatmapset_id;
-      this.lobby.SendMessageWithCoolTime("Alternative download link for [" + downloadLink + " " + map.beatmapset?.title + "]", "!mirror", 5000);
+      var beatconnectLink = this.beatconnectURL.replace(/\$\{beatmapset_id\}/g, map.beatmapset_id.toString());
+      var chimuLink = this.chimuURL.replace(/\$\{beatmapset_id\}/g, map.beatmapset_id.toString());
+      var beatmapView = map.beatmapset?.title.toString();
+      this.lobby.SendMessageWithCoolTime(`Alternative download link for ${beatmapView} : [${beatconnectLink} Beatconnect] | [${chimuLink} Chimu]`, "!mirror", 5000);
     } catch (e: any) {
       this.canResend = false;
       if (e instanceof FetchBeatmapError) {

--- a/src/plugins/MiscLoader.ts
+++ b/src/plugins/MiscLoader.ts
@@ -90,7 +90,7 @@ export class MiscLoader extends LobbyPlugin {
 
   async checkMirror(mapId: number): Promise<void> {
     try {
-      let map = await BeatmapRepository.getBeatmap(mapId);
+      let map = await BeatmapRepository.getBeatmap(mapId, this.lobby.gameMode);
       this.canResend = false;
       if (!map) {
         this.lobby.SendMessage("Current beatmap doesn't have mirror...");

--- a/src/webapi/WebApiClient.ts
+++ b/src/webapi/WebApiClient.ts
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs';
 import { UserProfile, trimProfile } from "./UserProfile";
 import { Beatmap, Beatmapset } from "./Beatmapsets";
 import { FetchBeatmapError, FetchBeatmapErrorReason, IBeatmapFetcher } from './BeatmapRepository';
+import { FetchProfileError, FetchProfileErrorReason } from './ProfileRepository';
 
 export interface ApiToken {
   token_type: string,
@@ -286,6 +287,21 @@ class WebApiClientClass implements IBeatmapFetcher {
         return null;
       }
       throw e;
+    }
+  }
+
+  async getPlayer(userID: number, mode: string): Promise<UserProfile> {
+    try {
+      const data = await this.accessApi(`https://osu.ppy.sh/api/v2/users/${userID}/${mode}`, {
+        method: "GET"
+      });
+      data.get_time = Date.now();
+      return data;
+    } catch (e: any) {
+      if (e.response?.status == 404) {
+        throw new FetchProfileError(FetchProfileErrorReason.NotFound);
+      }
+      throw new FetchProfileError(FetchProfileErrorReason.Unknown, e.message);
     }
   }
 


### PR DESCRIPTION
## Summary

- Handle exception if cached map not found
- Add `PlayMode` on `getBeatmap` parameter to specify cache
- Deprecate `ProfileRepository` because osu-web has removed `json-user` script in user profile
- Redirect `!rank` command to use `WebApiClient` instead of `ProfileRepository`
- Reformat mirror download link and add ~~Chimu.moe~~ Kitsu.moe as another mirror

## What's next

- Provide documentation about using osu-api v2 in `README.md`
- Deprecate WebsiteBeatmapFetcher and change it to WebApiClient (osu! dev said that json objects in osu-web are only used for web front-end and will soon removed so we need to change it to osu! api)