### PR TITLE
chore: change license metadata to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev:log": "ts-node src/cli/LogServer.ts"
   },
   "author": "gnsksz",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@discordjs/builders": "^0.12.0",
     "axios": "^0.25.0",


### PR DESCRIPTION
Package.json's license metadata is `ISC` while the repository is using `MIT` license.
This changes package.json's license metadata to `MIT`