### PR TITLE
docs: apply consistent use of plurals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The host rotation is managed with a queue. Players are added to the queue when j
 
 # Command List
 
-## Player Command
+## Player Commands
 |Command|Description|
 |:--|:--|
 |`!queue`| Shows host queue.|
@@ -15,7 +15,7 @@ The host rotation is managed with a queue. Players are added to the queue when j
 |`!regulations`| Shows any current regulations.|
 |`!rank`| Show player rank.|
  
-## Host Command
+## Host Commands
 |Command|Description|Example|
 |:--|:--|:--|
 |`!skip`| Transfers host to next player in the queue.||


### PR DESCRIPTION
`Player` and `Host` sections have more than 1 command, therefore they should use the plural of Command. "Commands", to be consistent with the [Administrator Commands](https://github.com/Meowhal/osu-ahr/blob/16ab9252b98ee71d9ccfdd9eb1fa725c826e6742/README.md?plain=1#L26) section.

