### PR TITLE
docs: readd removed exclamation points

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Note: You can also run your bot on discord. See the [Discord Integration](#disco
 # Configuration
 You can edit local.json to configure the bot's behavior.
 ## IRC Section
-- `server` : `string` Host name of osu IRC server.
-- `nick` : `string` Your osu account name
+- `server` : `string` Host name of osu! IRC server.
+- `nick` : `string` Your osu! account name
 - `opt.port` : `number` 
 - `opt.password` : `string` Your IRC password. You can get it from [https://osu.ppy.sh/p/irc](https://osu.ppy.sh/p/irc).
 ```json


### PR DESCRIPTION
Overlooked, actually.

After #57 was merged before #59 to avoid conflicts, #59 doesn't come with the [exclamation points](https://github.com/Meowhal/osu-ahr/pull/59/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-L125), so after merging all of the pull requests, the exclamation points were removed as a result along with it.

This pull request readds the removed exclamation points on "osu"