### PR TITLE
refactor: configure log4js outside try catch block

### DIFF
--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -13,9 +13,9 @@ console.log("starting up...");
 
 const config_path = "./config/log_discord.json";
 
-try {
-    log4js.configure(config_path);
+log4js.configure(config_path);
 
+try {
     const c = getIrcConfig();
     if (c.nick == "your account id" || c.opt.password == "you can get password from 'https://osu.ppy.sh/p/irc'") {
         logger.error("you must enter your account name and irc password in the config file. ");


### PR DESCRIPTION
**Description**
For some reason, no error appears in the console when running discord cli with a broken log4js configuration.

Just like in issue #51, where it just shows us
> starting up...

Let's say I configured `log_discord.json`'s discord appender like this, leading to a type that doesn't exist.
https://github.com/Meowhal/osu-ahr/blob/9273b56f7316a4ef8dbf2067ca5945bc0c17eac4/config/log_discord.json#L15-L21

Into this, log4js should give us an error that TestingError cannot be found because it doesn't exist. 

> ```diff
>  "discord": { 
> -     "type": "DiscordAppender", 
> +     "type": "TestingError", 
>     "layout": { 
>         "type": "pattern", 
>         "pattern": "%m" 
>     } 
>  }, 
> ```
 
Running discord cli with our current broken log4js configuration, we will get nothing but an immediate exit without any prompt at all.
 
```js
PS C:\Users\Ava\Documents\GitHub\osu-ahr> node ./dist/discord/index.js
starting up...
PS C:\Users\Ava\Documents\GitHub\osu-ahr>
```

Whats interesting here is that the try catch block didn't show us any errors, it's because in the try catch block right here,
https://github.com/Meowhal/osu-ahr/blob/9273b56f7316a4ef8dbf2067ca5945bc0c17eac4/src/discord/index.ts#L43-L46
in `catch` uses `logger`(log4js) to show us an error.
But, since log4js was not instantiated from the error, `catch` will show us nothing.

https://github.com/Meowhal/osu-ahr/blob/9273b56f7316a4ef8dbf2067ca5945bc0c17eac4/src/discord/index.ts#L16-L17

It is `log4js.configure()` error is whats causing it to immediately exit the process, while the try catch block didn't show us any errors because it is using log4js's `logger` that haven't instantiated yet to show us an error.

So, to make it show the error stack from log4js to us, move the `log4js.configure()` statement outside the try catch block.

```diff
- try {
-    log4js.configure(config_path);
+
+ log4js.configure(config_path);
+ try {
```

Now, running discord cli again, we should get an error stack shown to us.

```js
PS C:\Users\Ava\Documents\GitHub\osu-ahr> node ./dist/discord/index.js
starting up...
C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\configuration.js:31
      throw new Error(`Problem with log4js configuration: (${util.inspect(config, { depth: 5 })})`
      ^

Error: Problem with log4js configuration: ({
  appenders: {
    console: {
      type: 'console',
      layout: {
        type: 'pattern',
        pattern: '%[[%d{hh:mm:ss.SSS}][%p] %c -%] %m'
      }
    },
    console_f: { type: 'logLevelFilter', level: 'info', appender: 'console' },
    discord: {
      type: 'TestingError',
      layout: { type: 'pattern', pattern: '%m' }
    },
    discord_f: { type: 'logLevelFilter', level: 'info', appender: 'discord' },
    file_app: {
      type: 'multiFile',
      base: 'logs/app',
      property: 'channel',
      extension: '.log'
    },
    file_app_f: { type: 'logLevelFilter', level: 'info', appender: 'file_app' },
    file_irc: { type: 'file', filename: 'logs/irc.log' },
    file_cli: {
      type: 'multiFile',
      base: 'logs/cli',
      property: 'channel',
      extension: '.log'
    },
    file_cli_f: { type: 'logLevelFilter', level: 'info', appender: 'file_cli' },
    file_pm: { type: 'file', filename: 'logs/pm.log' },
    file_counter: { type: 'file', filename: 'logs/ct.log' },        
    file_webapi: { type: 'file', filename: 'logs/webapi.log' }      
  },
  categories: {
    default: {
      appenders: [ 'console_f', 'file_app', 'file_cli_f', 'discord_f' ],
      level: 'all'
    },
    irc: {
      appenders: [ 'console_f', 'file_app_f', 'file_irc', 'discord_f' ],
      level: 'all'
    },
    chat: {
      appenders: [ 'console_f', 'file_cli', 'discord_f' ],
      level: 'all'
    },
    inout: { appenders: [ 'console', 'file_cli', 'discord_f' ], level: 'all' },
    PMLogger: { appenders: [ 'console_f', 'file_pm', 'file_cli' ], level: 'all' },
    wcounter: { appenders: [ 'file_counter' ], level: 'all' },      
    webapi: { appenders: [ 'file_webapi' ], level: 'all' },
    discord: { appenders: [ 'console_f', 'file_app' ], level: 'all' 
}
  }
}) - appender "discord" is not valid (type "TestingError" could not 
be found)
    at C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\configuration.js:31:13
    at Array.forEach (<anonymous>)
    at Object.throwExceptionIf (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\configuration.js:29:9)
    at createAppender (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\index.js:65:17)
    at getAppender (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\index.js:55:20)
    at C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\index.js:92:19
    at Object.configure (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\logLevelFilter.js:13:20)
    at C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\index.js:89:27
    at Object.onlyOnMaster (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\clustering.js:85:50)
    at createAppender (C:\Users\Ava\Documents\GitHub\osu-ahr\node_modules\log4js\lib\appenders\index.js:87:21)

Node.js v17.9.0
PS C:\Users\Ava\Documents\GitHub\osu-ahr>
```
I labeled it as a refactor because it's a really minor change, doesn't really fix a core functionality issue.


Another way of implementation I found would be to
change 
https://github.com/Meowhal/osu-ahr/blob/9273b56f7316a4ef8dbf2067ca5945bc0c17eac4/src/discord/index.ts#L43-L46
Into this
> ```diff
> } catch (e: any) { 
> -    logger.error(e); 
> +    console.error(e); 
>     process.exit(1); 
> }
> ```

But I prefer to move the `log4js.configure()` statement outside the try catch to let log4js itself show the error instead of the try catch block in this PR.
