### PR TITLE
chore: add clean and compile npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/Meowhal/osu-ahr.git"
   },
   "scripts": {
+    "dist": "rimraf dist && tsc",
     "clean": "rimraf dist",
     "build": "tsc",
     "start": "node dist/cli/index.js",


### PR DESCRIPTION
**Description**
Not really necessary, just a basic all-in-one clean then compile script (basically `npm run clean` and `npm run build` together) instead of typing and entering `npm run clean`  which we have to wait, then type `npm run build` right after.

I am sure there is a better way to name that script, `build` was already taken so I named it `dist` for now.