### PR TITLE
chore: add browser env property

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 env:
   es2021: true
   node: true
+  browser: true
 extends:
   - standard
 parser: '@typescript-eslint/parser'


### PR DESCRIPTION
**Description**
The reason behind this change is because ESLint detects global variables for browsers like `document` as `not defined` in 

https://github.com/Meowhal/osu-ahr/blob/d036f0403fcb84e377d70dea9f55793f8b2d0f00/src/web/statics/main.js#L85-L98

This change makes it so that ESLint includes and predefine global variables (e.g document) used for browsers and not count them as errors.

More info: https://eslint.org/docs/user-guide/configuring/#specifying-environments
