### PR TITLE
refactor: full usage of template literals

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -84,6 +84,8 @@ rules:
     - "off"
   no-useless-catch:
     - "off"
+  no-useless-concat:
+    - error
   no-useless-escape:
     - error
   no-var:
@@ -91,6 +93,8 @@ rules:
   padded-blocks:
     - "off"
   prefer-const:
+    - error
+  prefer-template:
     - error
   quotes:
     - error
@@ -100,5 +104,7 @@ rules:
     - always
   space-before-function-paren:
     - "off"
+  template-curly-spacing:
+    - error
   yoda:
     - error

--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -25,34 +25,34 @@ export function logIrcEvent(client: IIrcClient) {
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;
-    ircLogger.debug('@reg %s', args?.join(', '));
+    ircLogger.debug(`@reg ${args?.join(', ')}`);
   });
   client.on('message', function (from, to, message) {
-    ircLogger.debug('@msg  %s => %s: %s', from, to, message);
+    ircLogger.debug(`@msg  ${from} => ${to}: ${message}`);
   });
   client.on('pm', function (nick, message) {
-    ircLogger.debug('@pm   %s: %s', nick, message);
+    ircLogger.debug(`@pm   ${nick}: ${message}`);
   });
   client.on('join', function (channel, who) {
-    ircLogger.debug('@join %s has joined %s', who, channel);
+    ircLogger.debug(`@join ${who} has joined ${channel}`);
   });
   client.on('part', function (channel, who, reason) {
-    ircLogger.debug('@part %s has left %s: %s', who, channel, reason);
+    ircLogger.debug(`@part ${who} has left ${channel}: ${reason}`);
   });
   client.on('kick', function (channel, who, by, reason) {
-    ircLogger.debug('@kick %s was kicked from %s by %s: %s', who, channel, by, reason);
+    ircLogger.debug(`@kick ${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
   client.on('invite', (channel, from) => {
     ircLogger.debug(`@invt ${from} invite you to ${channel}`);
   });
   client.on('notice', function (from, to, message) {
-    ircLogger.debug('@notice  %s => %s: %s', from, to, message);
+    ircLogger.debug(`@notice  ${from} => ${to}: ${message}`);
   });
   client.on('action', function (from, to, text, message) {
-    ircLogger.debug('@action  %s => %s: %s', from, to, text);
+    ircLogger.debug(`@action  ${from} => ${to}: ${text}`);
   });
   client.on('selfMessage', (target: string, toSend) => {
-    ircLogger.debug('@sent bot => %s: %s', target, toSend);
+    ircLogger.debug(`@sent bot => ${target}: ${toSend}`);
   });
 }
 

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -128,7 +128,7 @@ export class Lobby {
         this.handlePrivateMessage(nick, message);
       },
       kick: (channel: any, who: any, by: any, reason: any) => {
-        this.logger.info('%s was kicked from %s by %s: %s', who, channel, by, reason);
+        this.logger.info(`${who} was kicked from ${channel} by ${by}: ${reason}`);
       },
       part: (channel: string, nick: string) => {
         if (channel === this.channel) {
@@ -144,7 +144,7 @@ export class Lobby {
       selfMessage: (target: string, toSend: any) => {
         if (target === this.channel) {
           const r = toSend.replace(/\[http\S+\s([^\]]+)\]/g, '[http... $1]');
-          this.chatlogger.info('bot:%s', r);
+          this.chatlogger.info(`bot:${r}`);
         }
       }
     };
@@ -328,7 +328,7 @@ export class Lobby {
       this.ircClient.say(this.channel, message);
       this.ircClient.emit('sentMessage', this.channel, message);
       this.SentMessage.emit({ message });
-      //this.chatlogger.trace("%s:%s", "bot", message);
+      //this.chatlogger.trace(`bot:${message}`);
     }
   }
 
@@ -336,7 +336,7 @@ export class Lobby {
     this.ircClient.say(target, message);
     this.ircClient.emit('sentPrivateMessage', target, message);
     this.SentMessage.emit({ message });
-    this.chatlogger.info('%s:%s', `botbot->${target}`, message);
+    this.chatlogger.info(`botbot->${target}:${message}`);
   }
 
   SendMessageWithCoolTime(message: string | (() => string), tag: string, cooltimeMs: number): boolean {
@@ -442,16 +442,16 @@ export class Lobby {
         }
         this.PlayerChated.emit({ player: p, message });
         if (IsStatResponse(message)) {
-          this.chatlogger.trace('%s:%s', p.name, message);
+          this.chatlogger.trace(`${p.name}:${message}`);
         } else {
-          this.chatlogger.info('%s:%s', p.name, message);
+          this.chatlogger.info(`${p.name}:${message}`);
         }
       }
     }
   }
 
   private handleAction(from: string, to: string, message: string): void {
-    this.chatlogger.info('*%s:%s', from, message);
+    this.chatlogger.info(`*${from}:${message}`);
   }
 
   private handlePrivateMessage(from: string, message: string): void {
@@ -508,11 +508,11 @@ export class Lobby {
         break;
       case BanchoResponseType.AddedReferee:
         this.GetOrMakePlayer(c.params[0]).setRole(Roles.Referee);
-        this.logger.trace('AddedReferee : %s', c.params[0]);
+        this.logger.trace(`AddedReferee : ${c.params[0]}`);
         break;
       case BanchoResponseType.RemovedReferee:
         this.GetOrMakePlayer(c.params[0]).removeRole(Roles.Referee);
-        this.logger.trace('RemovedReferee : %s', c.params[0]);
+        this.logger.trace(`RemovedReferee : ${c.params[0]}`);
         break;
       case BanchoResponseType.ListRefs:
         this.listRefStart = Date.now();
@@ -522,7 +522,7 @@ export class Lobby {
         break;
       case BanchoResponseType.TeamChanged:
         this.GetOrMakePlayer(c.params[0]).team = c.params[1];
-        this.logger.trace('team changed : %s, %s', c.params[0], Teams[c.params[1]]);
+        this.logger.trace(`team changed : ${c.params[0]}, ${Teams[c.params[1]]}`);
         break;
       case BanchoResponseType.BeatmapChanged:
       case BanchoResponseType.MpBeatmapChanged:
@@ -530,7 +530,7 @@ export class Lobby {
           this.mapId = c.params[0];
           this.mapTitle = c.params[1];
           const changer = this.host ? `(by ${c.type === BanchoResponseType.BeatmapChanged ? this.host.name : 'bot'})` : '';
-          this.logger.info('beatmap changed%s : %s %s', changer, `https://osu.ppy.sh/b/${this.mapId}`, this.mapTitle);
+          this.logger.info(`beatmap changed${changer} : https://osu.ppy.sh/b/${this.mapId} ${this.mapTitle}`);
         }
         break;
       case BanchoResponseType.Settings:
@@ -554,7 +554,7 @@ export class Lobby {
         break;
       case BanchoResponseType.Unhandled:
         if (this.checkListRef(message)) break;
-        this.logger.debug('unhandled bancho response : %s', message);
+        this.logger.debug(`unhandled bancho response : ${message}`);
         break;
     }
     this.ReceivedBanchoResponse.emit({ message, response: c });
@@ -565,7 +565,7 @@ export class Lobby {
       if (Date.now() < this.listRefStart + this.option.listref_duration_ms) {
         const p = this.GetOrMakePlayer(message);
         p.setRole(Roles.Referee);
-        this.logger.trace('AddedReferee : %s', p.escaped_name);
+        this.logger.trace(`AddedReferee : ${p.escaped_name}`);
         return true;
       } else {
         this.listRefStart = 0;
@@ -576,7 +576,7 @@ export class Lobby {
   }
 
   RaiseReceivedChatCommand(player: Player, message: string): void {
-    this.logger.trace('custom command %s:%s', player.name, message);
+    this.logger.trace(`custom command ${player.name}:${message}`);
     if (player.isReferee && message.startsWith('!mp')) return;
     const { command, param } = parser.ParseChatCommand(message);
     if (command === '!info' || command === '!help') {
@@ -616,7 +616,7 @@ export class Lobby {
     const from = player.slot;
     player.slot = slot;
 
-    this.logger.trace('slot moved : %s, %d', username, slot);
+    this.logger.trace(`slot moved : ${username}, ${slot}`);
     this.PlayerMoved.emit({ player, from, to: slot });
   }
 
@@ -642,7 +642,7 @@ export class Lobby {
     const sc = this.CountPlayersStatus();
     this.PlayerFinished.emit({ player, score, isPassed, playersFinished: sc.finished, playersInGame: sc.inGame });
     if (!this.players.has(player)) {
-      this.logger.warn('未参加のプレイヤーがゲームを終えた: %s', username);
+      this.logger.warn(`未参加のプレイヤーがゲームを終えた: ${username}`);
       this.LoadMpSettingsAsync();
     }
   }
@@ -657,7 +657,7 @@ export class Lobby {
 
   RaiseAbortedMatch(): void {
     const sc = this.CountPlayersStatus();
-    this.logger.info('match aborted %d / %d', sc.finished, sc.inGame);
+    this.logger.info(`match aborted ${sc.finished} / ${sc.inGame}`);
     this.isMatching = false;
     this.players.forEach(p => p.mpstatus = MpStatuses.InLobby);
     this.AbortedMatch.emit({ playersFinished: sc.finished, playersInGame: sc.inGame });
@@ -703,7 +703,7 @@ export class Lobby {
       const p = this.GetPlayer(this.statParser.result.name);
       if (p) {
         p.laststat = this.statParser.result;
-        this.logger.info('parsed stat %s -> %s', p.name, StatStatuses[p.laststat.status]);
+        this.logger.info(`parsed stat ${p.name} -> ${StatStatuses[p.laststat.status]}`);
         this.ParsedStat.emit({ result: this.statParser.result, player: p, isPm });
       }
     }
@@ -775,7 +775,7 @@ export class Lobby {
     return new Promise<string>((resolve, reject) => {
       const ch = parser.EnsureMpChannelId(channel);
       if (ch === '') {
-        this.logger.error('invalid channel: %s', channel);
+        this.logger.error(`invalid channel: ${channel}`);
         reject('invalid channel');
         return;
       }
@@ -871,13 +871,13 @@ export class Lobby {
         this.setAsHost(player);
       }
       if (this.players.size > 16) {
-        this.logger.warn('joined 17th players: %s', player.name);
+        this.logger.warn(`joined 17th players: ${player.name}`);
         this.UnexpectedAction.emit(new Error('unexpected join'));
         return false;
       }
       return true;
     } else {
-      this.logger.warn('参加済みのプレイヤーが再度参加した: %s', player.name);
+      this.logger.warn(`参加済みのプレイヤーが再度参加した: ${player.name}`);
       this.UnexpectedAction.emit(new Error('unexpected join'));
       return false;
     }
@@ -894,12 +894,12 @@ export class Lobby {
         this.host = null;
       }
       if (this.hostPending === player) {
-        this.logger.warn('pending中にユーザーが離脱した pending host: %s', player.name);
+        this.logger.warn(`pending中にユーザーが離脱した pending host: ${player.name}`);
         this.hostPending = null;
       }
       return true;
     } else {
-      this.logger.warn('未参加のプレイヤーが退出した: %s', player.name);
+      this.logger.warn(`未参加のプレイヤーが退出した: ${player.name}`);
       this.UnexpectedAction.emit(new Error('unexpected left'));
       return false;
     }
@@ -908,7 +908,7 @@ export class Lobby {
   private setAsHost(player: Player): boolean {
     if (!this.players.has(player)) {
       this.transferHostTimeout.cancel();
-      this.logger.warn('未参加のプレイヤーがホストになった: %s', player.name);
+      this.logger.warn(`未参加のプレイヤーがホストになった: ${player.name}`);
       return false;
     }
 
@@ -916,7 +916,7 @@ export class Lobby {
       this.transferHostTimeout.cancel();
       this.hostPending = null;
     } else if (this.hostPending !== null) {
-      this.logger.warn('pending中に別のユーザーがホストになった pending: %s, host: %s', this.hostPending.name, player.name);
+      this.logger.warn(`pending中に別のユーザーがホストになった pending: ${this.hostPending.name}, host: ${player.name}`);
     } // pending === null は有効
 
     if (this.host) {
@@ -1028,7 +1028,7 @@ export class Lobby {
       c.setRole(Roles.Authorized);
       c.setRole(Roles.Referee);
       c.setRole(Roles.Creator);
-      this.logger.info('assigned %s creators role', this.ircClient.nick);
+      this.logger.info(`assigned ${this.ircClient.nick} creators role`);
     }
   }
 

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -301,9 +301,9 @@ export class Lobby {
     this.hostPending = user;
     this.transferHostTimeout.start(this.option.transferhost_timeout_ms);
     if (user.id !== 0) {
-      this.SendMessage('!mp host #' + user.id);
+      this.SendMessage(`!mp host #${user.id}`);
     } else {
-      this.SendMessage('!mp host ' + user.name);
+      this.SendMessage(`!mp host ${user.name}`);
     }
   }
 
@@ -336,7 +336,7 @@ export class Lobby {
     this.ircClient.say(target, message);
     this.ircClient.emit('sentPrivateMessage', target, message);
     this.SentMessage.emit({ message });
-    this.chatlogger.info('%s:%s', 'botbot->' + target, message);
+    this.chatlogger.info('%s:%s', `botbot->${target}`, message);
   }
 
   SendMessageWithCoolTime(message: string | (() => string), tag: string, cooltimeMs: number): boolean {
@@ -415,7 +415,7 @@ export class Lobby {
           resolve(result);
         }
       });
-      this.ircClient.say(byPm || !this.channel ? 'BanchoBot' : this.channel, '!stat ' + player.escaped_name);
+      this.ircClient.say(byPm || !this.channel ? 'BanchoBot' : this.channel, `!stat ${player.escaped_name}`);
     });
   }
 
@@ -530,7 +530,7 @@ export class Lobby {
           this.mapId = c.params[0];
           this.mapTitle = c.params[1];
           const changer = this.host ? `(by ${c.type === BanchoResponseType.BeatmapChanged ? this.host.name : 'bot'})` : '';
-          this.logger.info('beatmap changed%s : %s %s', changer, 'https://osu.ppy.sh/b/' + this.mapId, this.mapTitle);
+          this.logger.info('beatmap changed%s : %s %s', changer, `https://osu.ppy.sh/b/${this.mapId}`, this.mapTitle);
         }
         break;
       case BanchoResponseType.Settings:
@@ -664,7 +664,7 @@ export class Lobby {
   }
 
   RaiseNetError(err: Error): void {
-    this.logger.error('error occured : ' + err.message);
+    this.logger.error(`error occured : ${err.message}`);
     this.logger.error(err.stack);
     this.NetError.emit(err);
   }
@@ -721,7 +721,7 @@ export class Lobby {
   OnUserNotFound(): void {
     if (this.hostPending) {
       const p = this.hostPending;
-      this.logger.warn('occured OnUserNotFound : ' + p.name);
+      this.logger.warn(`occured OnUserNotFound : ${p.name}`);
       this.hostPending = null;
     }
   }
@@ -764,7 +764,7 @@ export class Lobby {
 
       });
       const trg = 'BanchoBot';
-      const msg = '!mp make ' + title;
+      const msg = `!mp make ${title}`;
       this.ircClient.say(trg, msg);
       this.ircClient.emit('sentMessage', trg, msg);
     });
@@ -984,7 +984,7 @@ export class Lobby {
     for (const p of this.plugins) {
       const ps = p.GetPluginStatus();
       if (ps !== '') {
-        s += '\n' + ps;
+        s += `\n${ps}`;
       }
     }
     return s;
@@ -1036,7 +1036,7 @@ export class Lobby {
     // ensure time is stop
     this.stopInfoMessageAnnouncement();
     if (this.option.info_message_announcement_interval_ms > 3 * 60 * 1000) {
-      this.logger.trace('started InfoMessageAnnouncement. interval = ' + this.option.info_message_announcement_interval_ms);
+      this.logger.trace(`started InfoMessageAnnouncement. interval = ${this.option.info_message_announcement_interval_ms}`);
       this.infoMessageAnnouncementTimeId = setInterval(() => {
         this.showInfoMessage();
         if (this.status !== LobbyStatus.Entered) {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -80,7 +80,7 @@ export function escapeUserName(name: string): string {
  * @param username
  */
 export function disguiseUserName(username: string): string {
-  return username[0] + '\u{200B}' + username.substring(1);
+  return `${username[0]}\u{200B}${username.substring(1)}`;
 }
 
 /**

--- a/src/cli/OahrBase.ts
+++ b/src/cli/OahrBase.ts
@@ -107,7 +107,7 @@ export class OahrBase {
   async enterLobbyAsync(id: string): Promise<void> {
     if (!this.isRegistered) await this.ensureRegisteredAsync();
     const channel = parser.EnsureMpChannelId(id);
-    logger.info('Entering lobby, channel : %s', channel);
+    logger.info(`Entering lobby, channel : ${channel}`);
     await this.lobby.EnterLobbyAsync(channel);
     await this.lobby.LoadMpSettingsAsync();
 

--- a/src/cli/OahrBase.ts
+++ b/src/cli/OahrBase.ts
@@ -95,11 +95,11 @@ export class OahrBase {
     // Remove all but ascii graphic characters
     name = name.replace(/[^ -~]/g, '');
     if (!this.isRegistered) await this.ensureRegisteredAsync();
-    logger.info('Making lobby, name : ' + name);
+    logger.info(`Making lobby, name : ${name}`);
     await this.lobby.MakeLobbyAsync(name);
-    this.lobby.SendMessage('!mp password ' + this.option.password);
+    this.lobby.SendMessage(`!mp password ${this.option.password}`);
     for (const p of this.option.invite_users) {
-      this.lobby.SendMessage('!mp invite ' + p);
+      this.lobby.SendMessage(`!mp invite ${p}`);
     }
     logger.info(`Made lobby : ${this.lobby.channel}`);
   }

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -61,7 +61,7 @@ export class OahrCli extends OahrBase {
               await this.makeLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
             } catch (e) {
-              logger.info('Failed to make a lobby : %s', e);
+              logger.info(`Failed to make a lobby : ${e}`);
               this.scene = this.scenes.exited;
             }
             break;
@@ -75,7 +75,7 @@ export class OahrCli extends OahrBase {
               await this.enterLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
             } catch (e) {
-              logger.info('Invalid channel : %s', e);
+              logger.info(`Invalid channel : ${e}`);
               this.scene = this.scenes.exited;
             }
             break;
@@ -96,7 +96,7 @@ export class OahrCli extends OahrBase {
           case '':
             break;
           default:
-            logger.info('Invalid command : %s', line);
+            logger.info(`Invalid command : ${line}`);
             break;
         }
       },
@@ -180,7 +180,7 @@ export class OahrCli extends OahrBase {
             } else if (l.command.startsWith('!') || l.command.startsWith('*')) {
               this.lobby.RaiseReceivedChatCommand(this.lobby.GetOrMakePlayer(this.client.nick), `${l.command} ${l.arg}`);
             } else {
-              console.log('Invalid command : %s', line);
+              console.log(`Invalid command : ${line}`);
             }
             break;
         }
@@ -233,7 +233,7 @@ export class OahrCli extends OahrBase {
     });
 
     r.on('line', line => {
-      logger.trace('Scene:%s, Line:%s', this.scene.name, line);
+      logger.trace(`Scene:${this.scene.name}, Line:${line}`);
       this.scene.action(line).then(() => {
         if (!this.exited) {
           r.setPrompt(this.prompt);

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -168,17 +168,17 @@ export class OahrCli extends OahrBase {
             break;
           case 'check_order':
             this.lobby.historyRepository.calcCurrentOrderAsName().then(r => {
-              logger.info('History order = ' + r.join(', '));
-              logger.info('Current order = ' + this.selector.hostQueue.map(p => p.name).join(', '));
+              logger.info(`History order = ${r.join(', ')}`);
+              logger.info(`Current order = ${this.selector.hostQueue.map(p => p.name).join(', ')}`);
             });
             break;
           case '':
             break;
           default:
             if (l.command.startsWith('!mp')) {
-              this.lobby.SendMessage('!mp ' + l.arg);
+              this.lobby.SendMessage(`!mp ${l.arg}`);
             } else if (l.command.startsWith('!') || l.command.startsWith('*')) {
-              this.lobby.RaiseReceivedChatCommand(this.lobby.GetOrMakePlayer(this.client.nick), l.command + ' ' + l.arg);
+              this.lobby.RaiseReceivedChatCommand(this.lobby.GetOrMakePlayer(this.client.nick), `${l.command} ${l.arg}`);
             } else {
               console.log('Invalid command : %s', line);
             }
@@ -262,7 +262,7 @@ export class OahrCli extends OahrBase {
 
   transitionToLobbyMenu() {
     this.scene = this.scenes.lobbyMenu;
-    this.scene.prompt = (this.lobby.channel || '') + ' > ';
+    this.scene.prompt = `${this.lobby.channel || ''} > `;
     console.log(lobbyMenuCommandsMessage);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,7 @@ try {
   const client = new irc.Client(c.server, c.nick, c.opt);
   client.on('error', err => {
     if (err.command === 'err_passwdmismatch') {
-      logger.error('%s: %s', err.command, err.args.join(' '));
+      logger.error(`${err.command}: ${err.args.join(' ')}`);
       logger.error('check your account id and password.');
       process.exit(1);
     }

--- a/src/discord/DiscordAppender.ts
+++ b/src/discord/DiscordAppender.ts
@@ -69,7 +69,7 @@ function createContent(ev: log4js.LoggingEvent, msg: string): string | MessageOp
       if (ev.data.length === 3) {
         return `> **${ev.data[1]}**: ${ev.data[2]}`;
       } else {
-        return '> ' + msg;
+        return `> ${msg}`;
       }
     case 'inout':
       const min = msg.match(/\+\x1b\[32m (.+?) \x1B\[0m/);
@@ -77,10 +77,10 @@ function createContent(ev: log4js.LoggingEvent, msg: string): string | MessageOp
       if (min || mout) {
         let msg = '';
         if (min) {
-          msg += '**in** ' + min[1] + ' ';
+          msg += `**in** ${min[1]} `;
         }
         if (mout) {
-          msg += '**out** ' + mout[1];
+          msg += `**out** ${mout[1]}`;
         }
         return { embeds: [new MessageEmbed().setColor(color).setDescription(msg)] };
       }
@@ -89,5 +89,5 @@ function createContent(ev: log4js.LoggingEvent, msg: string): string | MessageOp
   if (log4js.levels.WARN.level <= ev.level.level) {
     return { embeds: [new MessageEmbed().setColor(color).setDescription(msg)] };
   }
-  return '`' + ev.categoryName + '` ' + msg;
+  return `\`${ev.categoryName}\` ${msg}`;
 }

--- a/src/discord/DiscordBot.ts
+++ b/src/discord/DiscordBot.ts
@@ -54,7 +54,7 @@ export class DiscordBot {
     });
 
     this.discordClient.on('guildCreate', async guild => {
-      console.log('guildCreate ' + guild.name);
+      console.log(`guildCreate ${guild.name}`);
       await this.registerCommandsAndRoles(guild);
     });
 
@@ -154,8 +154,8 @@ export class DiscordBot {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.makeLobbyAsync(name);
     } catch (e: any) {
-      logger.error('couldn\'t make a tournament lobby. ' + e);
-      await interaction.editReply('😫 couldn\'t make a tournament lobby. ' + e.message);
+      logger.error(`couldn't make a tournament lobby. ${e}`);
+      await interaction.editReply(`😫 couldn't make a tournament lobby. ${e.message}`);
       ahr?.lobby.destroy();
       return;
     }
@@ -166,15 +166,15 @@ export class DiscordBot {
       await this.updateMatchSummary(ahr);
       await interaction.editReply(`😀 Created the lobby [Lobby History](https://osu.ppy.sh/mp/${lobbyNumber})`);
     } catch (e: any) {
-      logger.error('couldn\'t make a discord channel. ' + e);
-      await interaction.editReply('couldn\'t make a discord channel. ' + e.message);
+      logger.error(`couldn't make a discord channel. ${e}`);
+      await interaction.editReply(`couldn't make a discord channel. ${e.message}`);
     }
   }
 
   async enter(interaction: GuildCommandInteraction) {
     await interaction.deferReply();
     const lobbyNumber = this.resolveLobbyId(interaction, true);
-    const lobbyId = '#mp_' + lobbyNumber;
+    const lobbyId = `#mp_${lobbyNumber}`;
     if (!lobbyNumber) {
       await interaction.editReply('error lobby_id required.');
       return;
@@ -198,8 +198,8 @@ export class DiscordBot {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.enterLobbyAsync(lobbyId);
     } catch (e) {
-      logger.error('couldn\'t enter the tournament lobby. ' + e);
-      await interaction.editReply('😫 couldn\'t enter the tournament lobby. ' + e);
+      logger.error(`couldn't enter the tournament lobby. ${e}`);
+      await interaction.editReply(`😫 couldn't enter the tournament lobby. ${e}`);
       ahr?.lobby.destroy();
       return;
     }
@@ -208,14 +208,14 @@ export class DiscordBot {
       this.registeAhr(ahr, interaction);
       // ロビー用チャンネルからenterコマンドを引数無しで呼び出している場合はそのチャンネルでログ転送を開始する
       const ch = interaction.guild?.channels.cache.get(interaction.channelId);
-      if (ch && lobbyId === ('#' + ch.name)) {
+      if (ch && lobbyId === (`#${ch.name}`)) {
         ahr.startTransferLog(ch.id);
       }
       await this.updateMatchSummary(ahr);
       await interaction.editReply(`😀 Entered the lobby [Lobby History](https://osu.ppy.sh/mp/${lobbyNumber})`);
     } catch (e) {
-      logger.error('couldn\'t make a discord channel.  ' + e);
-      await interaction.editReply('😫 couldn\'t make a discord channel.  ' + e);
+      logger.error(`couldn't make a discord channel.  ${e}`);
+      await interaction.editReply(`😫 couldn't make a discord channel.  ${e}`);
     }
   }
 
@@ -243,8 +243,8 @@ export class DiscordBot {
     try {
       await interaction.editReply({ embeds: [ahr.createDetailInfoEmbed()] });
     } catch (e: any) {
-      logger.error('@discordbot.info ' + e);
-      await interaction.editReply('😫 error! ' + e.message);
+      logger.error(`@discordbot.info ${e}`);
+      await interaction.editReply(`😫 error! ${e.message}`);
     }
   }
 
@@ -263,10 +263,10 @@ export class DiscordBot {
     const msg = interaction.options.getString('message', true);
     if ((msg.startsWith('!') && !msg.startsWith('!mp ')) || msg.startsWith('*')) {
       ahr.lobby.RaiseReceivedChatCommand(ahr.lobby.GetOrMakePlayer(ahr.client.nick), msg);
-      await interaction.editReply('executed: ' + msg);
+      await interaction.editReply(`executed: ${msg}`);
     } else {
       ahr.lobby.SendMessage(msg);
-      await interaction.editReply('sent: ' + msg);
+      await interaction.editReply(`sent: ${msg}`);
     }
   }
 
@@ -287,8 +287,8 @@ export class DiscordBot {
       await ahr.lobby.CloseLobbyAsync();
       await interaction.editReply('Closed the lobby');
     } catch (e) {
-      logger.error('@discordbot.close ' + e);
-      await interaction.editReply('😫 error! ' + e);
+      logger.error(`@discordbot.close ${e}`);
+      await interaction.editReply(`😫 error! ${e}`);
     }
   }
 
@@ -309,14 +309,14 @@ export class DiscordBot {
       await ahr.lobby.QuitLobbyAsync();
       await interaction.editReply('Stopped managing the lobby');
     } catch (e) {
-      logger.error('@discordbot.quit ' + e);
-      await interaction.editReply('😫 error! ' + e);
+      logger.error(`@discordbot.quit ${e}`);
+      await interaction.editReply(`😫 error! ${e}`);
     }
   }
 
   async handleButtonInteraction(interaction: ButtonInteraction<'present'>, command: string, lobbyNumber: string) {
     if (!interaction.guild) return;
-    const lobbyId = '#mp_' + lobbyNumber;
+    const lobbyId = `#mp_${lobbyNumber}`;
     const ahr = this.ahrs[lobbyId];
     if (!ahr) {
       await interaction.reply({ content: `${lobbyId} - the lobby has already been unmanaged.`, ephemeral: true });
@@ -344,12 +344,12 @@ export class DiscordBot {
       }
       await this.updateMatchSummary(ahr);
     } catch (e) {
-      logger.error('@handleButtonInteraction ' + e);
+      logger.error(`@handleButtonInteraction ${e}`);
     }
   }
 
   async getOrCreateMatchChannel(guild: Guild, lobbyNumber: string): Promise<TextChannel> {
-    const lobbyId = 'mp_' + lobbyNumber;
+    const lobbyId = `mp_${lobbyNumber}`;
     const dc = guild.channels.cache.find(c => c.name === lobbyId);
     if (dc) return dc as TextChannel;
     const role = guild.roles.cache.find(r => r.name === ADMIN_ROLE.name);
@@ -468,7 +468,7 @@ export class DiscordBot {
       if (asNumber) {
         return m[1];
       } else {
-        return '#' + m[0];
+        return `#${m[0]}`;
       }
 
     }

--- a/src/discord/OahrDiscord.ts
+++ b/src/discord/OahrDiscord.ts
@@ -68,7 +68,7 @@ export class OahrDiscord extends OahrBase {
     const host = lobby.host?.name ?? 'none';
 
 
-    const embed = new MessageEmbed().setColor('BLURPLE').setTitle('Lobby Information - ' + name).setURL(`https://osu.ppy.sh/community/matches/${lid}`);
+    const embed = new MessageEmbed().setColor('BLURPLE').setTitle(`Lobby Information - ${name}`).setURL(`https://osu.ppy.sh/community/matches/${lid}`);
     embed.addField('lobby', `id:${lid}, status:${LobbyStatus[lobby.status]}, host:${host}, players:${lobby.players.size}, name:${name}`,);
     const refs = Array.from(lobby.playersMap.values()).filter(v => v.isReferee).map(v => v.name).join(',');
     if (refs) {
@@ -127,19 +127,19 @@ export class OahrDiscord extends OahrBase {
   createMenuButton() {
     const cid = this.lobby.channel; // #mp_xxxx
     if (!cid) throw new Error('invalid ahr lobby state. channel is undefined');
-    return new MessageActionRow().addComponents(new MessageButton().setLabel('Menu').setStyle(MessageButtonStyles.PRIMARY).setCustomId('menu,' + cid));
+    return new MessageActionRow().addComponents(new MessageButton().setLabel('Menu').setStyle(MessageButtonStyles.PRIMARY).setCustomId(`menu,${cid}`));
   }
 
   createControllButtons() {
     const cid = this.lobby.channel; // #mp_xxxx
     if (!cid) throw new Error('invalid ahr lobby state. channel is undefined');
     const btn1 = new MessageButton();
-    const btn2 = new MessageButton().setLabel('close').setStyle(MessageButtonStyles.DANGER).setCustomId('close,' + cid); // close,#mp_xxxx
+    const btn2 = new MessageButton().setLabel('close').setStyle(MessageButtonStyles.DANGER).setCustomId(`close,${cid}`); // close,#mp_xxxx
 
     if (this.transferLog) {
-      btn1.setLabel('Stop transfer').setStyle(MessageButtonStyles.SECONDARY).setCustomId('stopLog,' + cid); // stopLog,#mp_xxxx
+      btn1.setLabel('Stop transfer').setStyle(MessageButtonStyles.SECONDARY).setCustomId(`stopLog,${cid}`); // stopLog,#mp_xxxx
     } else {
-      btn1.setLabel('Start transfer').setStyle(MessageButtonStyles.PRIMARY).setCustomId('startLog,' + cid); // stopLog,#mp_xxxx
+      btn1.setLabel('Start transfer').setStyle(MessageButtonStyles.PRIMARY).setCustomId(`startLog,${cid}`); // stopLog,#mp_xxxx
     }
 
     const row = new MessageActionRow().addComponents(btn1, btn2);

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -27,7 +27,7 @@ try {
   const ircClient = new irc.Client(c.server, c.nick, c.opt);
   ircClient.on('error', err => {
     if (err.command === 'err_passwdmismatch') {
-      logger.error('%s: %s', err.command, err.args.join(' '));
+      logger.error(`${err.command}: ${err.args.join(' ')}`);
       logger.error('check your account id and password.');
       process.exit(1);
     }

--- a/src/dummies/DummyHistoryFetcher.ts
+++ b/src/dummies/DummyHistoryFetcher.ts
@@ -147,7 +147,7 @@ export class DummyHistoryFecher implements IHistoryFetcher {
         last_visit: this.match.start_time,
         pm_friends_only: false,
         profile_colour: null,
-        username: 'user' + userId,
+        username: `user${userId}`,
         country: {
           code: 'AA',
           name: 'AA'

--- a/src/dummies/DummyIrcClient.ts
+++ b/src/dummies/DummyIrcClient.ts
@@ -60,7 +60,7 @@ export class DummyIrcClient extends EventEmitter implements IIrcClient {
       this.channel = channel;
     }
     this.emit('join', channel, who, this.msg);
-    this.emit('join' + channel, who, this.msg);
+    this.emit(`join${channel}`, who, this.msg);
   }
 
   // チャンネル退出イベントを発行する
@@ -69,7 +69,7 @@ export class DummyIrcClient extends EventEmitter implements IIrcClient {
       this.channel = '';
     }
     this.emit('part', channel, who, this.msg);
-    this.emit('part' + channel, who, this.msg);
+    this.emit(`part${channel}`, who, this.msg);
   }
 
   // メッセージイベントを発行する
@@ -85,7 +85,7 @@ export class DummyIrcClient extends EventEmitter implements IIrcClient {
     this.emit('message', from, to, message, this.msg);
     if (to === this.channel) {
       this.emit('message#', from, to, message, this.msg);
-      this.emit('message' + to, from, message, this.msg);
+      this.emit(`message${to}`, from, message, this.msg);
     }
     if (to === this.nick) {
       this.emit('pm', from, message, this.msg);
@@ -276,7 +276,7 @@ export class DummyIrcClient extends EventEmitter implements IIrcClient {
       }
       setImmediate(() => {
         const id = '12345';
-        this.raiseJoin('#mp_' + id, this.nick);
+        this.raiseJoin(`#mp_${id}`, this.nick);
         this.emulateMessage('BanchoBot', this.nick, `Created the tournament match https://osu.ppy.sh/mp/${id} ${title}`);
       });
     } else if (target === this.channel) {
@@ -331,8 +331,8 @@ export class DummyIrcClient extends EventEmitter implements IIrcClient {
             m('Started the match');
           } else {
             // カウントダウンや分表示は面倒なので省略
-            m('Match starts in ' + mp.arg + ' seconds');
-            m('Queued the match to start in ' + mp.arg + ' seconds');
+            m(`Match starts in ${mp.arg} seconds`);
+            m(`Queued the match to start in ${mp.arg} seconds`);
           }
           break;
         case 'aborttimer':

--- a/src/dummies/FakeBeatmapFetcher.ts
+++ b/src/dummies/FakeBeatmapFetcher.ts
@@ -119,7 +119,7 @@ export class FakeBeatmapFetcher implements IBeatmapFetcher {
     const map = {
       ...this.beatmapTemplate,
       id: id,
-      url: 'https://osu.ppy.sh/beatmaps/' + id,
+      url: `https://osu.ppy.sh/beatmaps/${id}`,
       mode: MODES[mode.id],
       mode_int: mode.id,
       convert: false,

--- a/src/parsers/CommandParser.ts
+++ b/src/parsers/CommandParser.ts
@@ -243,10 +243,10 @@ export namespace parser {
   export function EnsureMpChannelId(id: string): string {
     if (!id || id === '') return '';
     if (id.match(/^#mp_\d+$/)) return id;
-    if (id.match(/^\d+$/)) return '#mp_' + id;
+    if (id.match(/^\d+$/)) return `#mp_${id}`;
     const m = id.match(/^https:\/\/osu\.ppy\.sh\/mp\/(\d+)$/);
 
-    if (m) return '#mp_' + m[1];
+    if (m) return `#mp_${m[1]}`;
     else return '';
   }
 
@@ -267,7 +267,7 @@ export namespace parser {
     message = message.trimRight();
     let m = message.match(/^!mp\s+(\w+)\s*(.*?)$/);
     if (m) {
-      return { command: '!' + m[1].toLowerCase(), param: m[2] };
+      return { command: `!${m[1].toLowerCase()}`, param: m[2] };
     }
     m = message.match(/^([!*]\w+)\s*(.*?)$/);
     if (m) {

--- a/src/parsers/MpSettingsParser.ts
+++ b/src/parsers/MpSettingsParser.ts
@@ -85,7 +85,7 @@ export class MpSettingsParser {
         slot: parseInt(m[1]),
         ready: m[2].trim(),
         id: parseInt(m[3]),
-        profile: 'https://osu.ppy.sh/u/' + m[3],
+        profile: `https://osu.ppy.sh/u/${m[3]}`,
         name: m[4].trim(),
         isHost: m[6] === undefined ? false : m[6].includes('Host'),
         team: team,

--- a/src/parsers/StatParser.ts
+++ b/src/parsers/StatParser.ts
@@ -20,7 +20,7 @@ export class StatResult {
     this.date = date;
   }
   toString(): string {
-    return `Stats for (${this.name})[https://osu.ppy.sh/u/${this.id}]${this.status === StatStatuses.None ? '' : ' is ' + StatStatuses[this.status]}:
+    return `Stats for (${this.name})[https://osu.ppy.sh/u/${this.id}]${this.status === StatStatuses.None ? '' : ` is ${StatStatuses[this.status]}`}:
 Score:    ${this.score} (#${this.rank})
 Plays:    ${this.plays} (lv${this.level})
 Accuracy: ${this.accuracy}%`;

--- a/src/plugins/AfkKicker.ts
+++ b/src/plugins/AfkKicker.ts
@@ -172,22 +172,22 @@ export class AfkKicker extends LobbyPlugin {
       case '*afkkick_threshold':
         let th = parseInt(param);
         if (Number.isNaN(th)) {
-          this.logger.warn('invalid *afkkick_threshold param : %s', param);
+          this.logger.warn(`invalid *afkkick_threshold param : ${param}`);
           return;
         }
         th = Math.max(th, 1);
         this.option.threshold = th;
-        this.logger.info('afkkicker.threshold was set to %s', th);
+        this.logger.info(`afkkicker.threshold was set to ${th}`);
         break;
       case '*afkkick_cooltime':
         let ct = parseInt(param);
         if (Number.isNaN(ct)) {
-          this.logger.warn('invalid *afkkick_cooltime param : %s', param);
+          this.logger.warn(`invalid *afkkick_cooltime param : ${param}`);
           return;
         }
         ct = Math.max(ct, 10000);
         this.option.cooltime_ms = ct;
-        this.logger.info('afkkicker.cool_time_ms was set to %s', ct);
+        this.logger.info(`afkkicker.cool_time_ms was set to ${ct}`);
         break;
     }
   }

--- a/src/plugins/AfkKicker.ts
+++ b/src/plugins/AfkKicker.ts
@@ -152,9 +152,9 @@ export class AfkKicker extends LobbyPlugin {
     if (stat.afkPoint < 0) {
       stat.afkPoint = 0;
     } else if (this.option.threshold <= stat.afkPoint) {
-      this.lobby.SendMessage('!mp kick ' + player.escaped_name);
+      this.lobby.SendMessage(`!mp kick ${player.escaped_name}`);
       this.lobby.SendMessage('bot: kicked afk player.');
-      this.logger.info('kicked ' + player.escaped_name);
+      this.logger.info(`kicked ${player.escaped_name}`);
     }
   }
 
@@ -197,7 +197,7 @@ export class AfkKicker extends LobbyPlugin {
       .filter(([player, stat]) => stat.afkPoint > 0)
       .map(([player, stat]) => `${player.escaped_name}: ${stat.afkPoint}`).join(',');
     if (points) {
-      points = '\n  points: ' + points;
+      points = `\n  points: ${points}`;
     }
     return `-- AFK Kicker --
   status: ${this.option.enabled ? 'enabled' : 'disabled'}, threshold: ${this.option.threshold}, cooltime: ${this.option.cooltime_ms} (ms)${points}`;

--- a/src/plugins/AutoHostSelector.ts
+++ b/src/plugins/AutoHostSelector.ts
@@ -357,9 +357,9 @@ export class AutoHostSelector extends LobbyPlugin {
       let m = this.hostQueue.map(c => disguiseUserName(c.name)).join(', ');
       this.logger.trace(m);
       if (this.option.host_order_chars_limit < m.length) {
-        m = m.substring(0, this.option.host_order_chars_limit) + '...';
+        m = `${m.substring(0, this.option.host_order_chars_limit)}...`;
       }
-      return 'host order : ' + m;
+      return `host order : ${m}`;
     }, '!queue', this.option.host_order_cooltime_ms);
   }
 

--- a/src/plugins/AutoHostSelector.ts
+++ b/src/plugins/AutoHostSelector.ts
@@ -115,7 +115,7 @@ export class AutoHostSelector extends LobbyPlugin {
     if (isMpSettingResult) return;
 
     this.hostQueue.push(player);
-    this.logger.trace('added %s', player.name);
+    this.logger.trace(`added ${player.name}`);
     if (this.hostQueue.length === 1) {
       this.logger.trace('appoint first player to host');
       this.changeHost();
@@ -152,7 +152,7 @@ export class AutoHostSelector extends LobbyPlugin {
     if (this.lobby.isMatching) return; // 試合中は何もしない
 
     if (this.hostQueue[0] === newhost) {
-      this.logger.trace('a new host has been appointed:%s', newhost.name);
+      this.logger.trace(`a new host has been appointed:${newhost.name}`);
     } else {
       // ホストがキューの先頭以外に変更された場合
       if (!this.lobby.hostPending) {
@@ -400,7 +400,7 @@ export class AutoHostSelector extends LobbyPlugin {
       }
     }
     if (this.logger.isTraceEnabled()) {
-      this.logger.trace('skipto: %s', this.hostQueue.map(p => p.name).join(', '));
+      this.logger.trace(`skipto: ${this.hostQueue.map(p => p.name).join(', ')}`);
     }
     this.raiseOrderChanged('rotated');
     this.changeHost();
@@ -414,7 +414,7 @@ export class AutoHostSelector extends LobbyPlugin {
     if (typeof (order) === 'string') {
       const players = order.split(',').map(t => this.lobby.GetPlayer(revealUserName(t.trim()))).filter(p => p !== null) as Player[];
       if (players.length === 0) {
-        this.logger.info('Faild reorder, invalid order string : %s', order);
+        this.logger.info(`Faild reorder, invalid order string : ${order}`);
       } else {
         this.Reorder(players);
       }
@@ -443,8 +443,8 @@ export class AutoHostSelector extends LobbyPlugin {
     }
 
     this.logger.trace('validate queue.');
-    this.logger.trace('  old: %s', Array.from(this.lobby.players).map(p => p.name).join(', '));
-    this.logger.trace('  new: %s', que.map(p => p.name).join(', '));
+    this.logger.trace(`  old: ${Array.from(this.lobby.players).map(p => p.name).join(', ')}`);
+    this.logger.trace(`  new: ${que.map(p => p.name).join(', ')}`);
 
     return isValid;
   }
@@ -465,9 +465,9 @@ export class AutoHostSelector extends LobbyPlugin {
     }
     if (this.hostQueue[0] !== this.lobby.host) {
       this.lobby.TransferHost(this.hostQueue[0]);
-      this.logger.trace('sent !mp host %s', this.hostQueue[0].name);
+      this.logger.trace(`sent !mp host ${this.hostQueue[0].name}`);
     } else {
-      this.logger.trace('%s is already host', this.hostQueue[0].name);
+      this.logger.trace(`${this.hostQueue[0].name} is already host`);
     }
   }
 
@@ -478,7 +478,7 @@ export class AutoHostSelector extends LobbyPlugin {
     const current = this.hostQueue.shift() as Player;
     this.hostQueue.push(current);
     if (this.logger.isTraceEnabled() && showLog) {
-      this.logger.trace('rotated host queue: %s', this.hostQueue.map(p => p.name).join(', '));
+      this.logger.trace(`rotated host queue: ${this.hostQueue.map(p => p.name).join(', ')}`);
     }
     this.raiseOrderChanged('rotated');
   }
@@ -491,7 +491,7 @@ export class AutoHostSelector extends LobbyPlugin {
     const i = this.hostQueue.indexOf(player);
     if (i !== -1) {
       this.hostQueue.splice(i, 1);
-      this.logger.trace('removed %s', player.name);
+      this.logger.trace(`removed ${player.name}`);
       this.raiseOrderChanged('removed');
       return true;
     } else {

--- a/src/plugins/AutoStartTimer.ts
+++ b/src/plugins/AutoStartTimer.ts
@@ -42,7 +42,7 @@ export class AutoStartTimer extends LobbyPlugin {
       case '*autostart_time':
         let ct = parseInt(param);
         if (Number.isNaN(ct)) {
-          this.logger.warn('invalid *autostart_time param : %s', param);
+          this.logger.warn(`invalid *autostart_time param : ${param}`);
           return;
         }
         if (ct < WAITINGTIME_MIN) {

--- a/src/plugins/HostSkipper.ts
+++ b/src/plugins/HostSkipper.ts
@@ -104,7 +104,7 @@ export class HostSkipper extends LobbyPlugin {
 
   private onParsedStat(player: Player, result: StatResult, isPm: boolean): void {
     if (!isPm && this.lobby.host === player && this.statIsAfk(result.status) && !this.lobby.isMatching) {
-      this.logger.trace('passed afk check %s -> %s', result.name, StatStatuses[result.status]);
+      this.logger.trace(`passed afk check ${result.name} -> ${StatStatuses[result.status]}`);
       if (this.option.afk_check_do_skip) {
         this.Skip();
       } else {
@@ -135,22 +135,22 @@ export class HostSkipper extends LobbyPlugin {
 
   private vote(player: Player): void {
     if (this.voting.passed) {
-      this.logger.debug('vote from %s was ignored, already skipped', player.name);
+      this.logger.debug(`vote from ${player.name} was ignored, already skipped`);
     } else if (this.elapsedSinceHostChanged < this.option.vote_cooltime_ms) {
-      this.logger.debug('vote from %s was ignored, at cool time.', player.name);
+      this.logger.debug(`vote from ${player.name} was ignored, at cool time.`);
       if (player.isHost) {
         const secs = (this.option.vote_cooltime_ms - this.elapsedSinceHostChanged) / 1000;
         this.lobby.SendMessage(`skip command is in cooltime. you have to wait ${secs.toFixed(2)} sec(s).`);
       }
     } else if (player.isHost) {
-      this.logger.debug('host(%s) sent !skip command', player.name);
+      this.logger.debug(`host(${player.name}) sent !skip command`);
       this.Skip();
     } else {
       if (this.voting.Vote(player)) {
-        this.logger.trace('accept skip request from %s', player.name);
+        this.logger.trace(`accept skip request from ${player.name}`);
         this.checkSkipCount(true);
       } else {
-        this.logger.debug('vote from %s was ignored, double vote', player.name);
+        this.logger.debug(`vote from ${player.name} was ignored, double vote`);
       }
     }
   }
@@ -175,10 +175,10 @@ export class HostSkipper extends LobbyPlugin {
 
   SkipTo(username: string): void {
     if (!this.lobby.Includes(username)) {
-      this.logger.info('invalid username @skipto : %s', username);
+      this.logger.info(`invalid username @skipto : ${username}`);
       return;
     }
-    this.logger.info('do skipTo : %s', username);
+    this.logger.info(`do skipTo : ${username}`);
     this.StopTimer();
     this.SendPluginMessage('skipto', [username]);
   }
@@ -198,7 +198,7 @@ export class HostSkipper extends LobbyPlugin {
       if (!this.lobby.isMatching && this.lobby.host === target) {
         try {
           const stat1 = await this.lobby.RequestStatAsync(target, true, this.option.afk_check_timeout_ms);
-          this.logger.trace('stat check phase 1 %s -> %s', stat1.name, StatStatuses[stat1.status]);
+          this.logger.trace(`stat check phase 1 ${stat1.name} -> ${StatStatuses[stat1.status]}`);
           if (this.afkTimer !== undefined && this.lobby.host === target && this.statIsAfk(stat1.status)) {
             // double check and show stat for players
             await this.lobby.RequestStatAsync(target, false, this.option.afk_check_timeout_ms);

--- a/src/plugins/LobbyKeeper.ts
+++ b/src/plugins/LobbyKeeper.ts
@@ -94,7 +94,7 @@ export class LobbyKeeper extends LobbyPlugin {
         this.option.mode = r;
         return;
       } else {
-        throw new Error('Invalid Option. LobbyKeeper.mode : ' + mode);
+        throw new Error(`Invalid Option. LobbyKeeper.mode : ${mode}`);
       }
     }
 
@@ -110,7 +110,7 @@ export class LobbyKeeper extends LobbyPlugin {
       return;
     }
 
-    throw new Error('Invalid Option. LobbyKeeper.mode : ' + mode);
+    throw new Error(`Invalid Option. LobbyKeeper.mode : ${mode}`);
   }
 
   private setSizeOption(size: any) {
@@ -122,11 +122,11 @@ export class LobbyKeeper extends LobbyPlugin {
     }
 
     if (typeof size !== 'number') {
-      throw new Error('invalid size ' + size);
+      throw new Error(`invalid size ${size}`);
     }
 
     if (size < 0 || size > 16 || isNaN(size)) {
-      throw new Error('invalid size ' + size);
+      throw new Error(`invalid size ${size}`);
     }
     this.option.size = size;
     this.slotKeeper.size = size;
@@ -146,7 +146,7 @@ export class LobbyKeeper extends LobbyPlugin {
       this.option.mods = Mod.removeInvalidCombinations(mods);
       return;
     }
-    throw new Error('Invalid Option. LobbyKeeper.mods : ' + mods);
+    throw new Error(`Invalid Option. LobbyKeeper.mods : ${mods}`);
   }
 
   private tryParseModeParams(param: string) {
@@ -177,7 +177,7 @@ export class LobbyKeeper extends LobbyPlugin {
       const score = ScoreMode.from(param, true);
       return { team: this.option.mode?.team ?? TeamMode.HeadToHead, score };
     } catch {
-      throw new Error('Invalid Option. LobbyKeeper.mode : ' + param);
+      throw new Error(`Invalid Option. LobbyKeeper.mode : ${param}`);
     }
   }
 
@@ -269,7 +269,7 @@ export class LobbyKeeper extends LobbyPlugin {
       }
 
     } catch (e: any) {
-      this.logger.error('@LobbyKeeper#onParsedSettings ' + e?.message);
+      this.logger.error(`@LobbyKeeper#onParsedSettings ${e?.message}`);
     }
   }
 

--- a/src/plugins/MapChecker.ts
+++ b/src/plugins/MapChecker.ts
@@ -106,7 +106,7 @@ export class MapChecker extends LobbyPlugin {
       }
       if (p.num_violations_allowed !== undefined) {
         this.option.num_violations_allowed = p.num_violations_allowed;
-        this.logger.info('num_violations_allowed was set to ' + p.num_violations_allowed);
+        this.logger.info(`num_violations_allowed was set to ${p.num_violations_allowed}`);
       }
       let changed = false;
       if (p.star_min !== undefined) {
@@ -148,7 +148,7 @@ export class MapChecker extends LobbyPlugin {
       }
 
       if (changed) {
-        const m = 'New regulation: ' + this.validator.GetDescription();
+        const m = `New regulation: ${this.validator.GetDescription()}`;
         this.lobby.SendMessage(m);
         this.logger.info(m);
       }
@@ -161,7 +161,7 @@ export class MapChecker extends LobbyPlugin {
     if (this.option.enabled) {
       return this.validator.GetDescription();
     } else {
-      return 'Disabled (' + this.validator.GetDescription() + ')';
+      return `Disabled (${this.validator.GetDescription()})`;
     }
   }
 
@@ -330,7 +330,7 @@ export class MapValidator {
       if (violationMsgs.length === 1) {
         message = `${mapDesc} was rejected because ${violationMsgs[0]}`;
       } else {
-        message = `${mapDesc} was rejected because of following reason:\n${violationMsgs.map(m => '- ' + m).join('\n')}`;
+        message = `${mapDesc} was rejected because of following reason:\n${violationMsgs.map(m => `- ${m}`).join('\n')}`;
       }
       return { rate, message };
     } else {

--- a/src/plugins/MapRecaster.ts
+++ b/src/plugins/MapRecaster.ts
@@ -27,7 +27,7 @@ export class MapRecaster extends LobbyPlugin {
     if (command === '!update') {
       if (this.canRecast) {
         this.canRecast = false;
-        this.lobby.SendMessage('!mp map ' + this.lobby.mapId);
+        this.lobby.SendMessage(`!mp map ${this.lobby.mapId}`);
       }
     }
   }

--- a/src/plugins/MatchAborter.ts
+++ b/src/plugins/MatchAborter.ts
@@ -74,7 +74,7 @@ export class MatchAborter extends LobbyPlugin {
     if (!this.lobby.isMatching) return;
     if (command === '!abort') {
       if (player === this.lobby.host) {
-        this.logger.trace('host(%s) sent !abort command', player.name);
+        this.logger.trace(`host(${player.name}) sent !abort command`);
         this.doAbort();
       } else {
         this.vote(player);
@@ -89,10 +89,10 @@ export class MatchAborter extends LobbyPlugin {
   private vote(player: Player): void {
     if (this.voting.passed) return;
     if (this.voting.Vote(player)) {
-      this.logger.trace('accept abort request from %s (%s)', player.name, this.voting.toString());
+      this.logger.trace(`accept abort request from ${player.name} (${this.voting.toString()})`);
       this.checkVoteCount(true);
     } else {
-      this.logger.trace('vote from %s was ignored', player.name);
+      this.logger.trace(`vote from ${player.name} was ignored`);
     }
   }
 

--- a/src/plugins/MatchStarter.ts
+++ b/src/plugins/MatchStarter.ts
@@ -115,7 +115,7 @@ export class MatchStarter extends LobbyPlugin {
   private vote(player: Player): void {
     if (this.voting.passed) return;
     if (this.voting.Vote(player)) {
-      this.logger.trace('accepted start request from %s', player.name);
+      this.logger.trace(`accepted start request from ${player.name}`);
       this.checkVoteCount(true);
     } else {
       this.logger.trace('vote was ignored');

--- a/src/plugins/MatchStarter.ts
+++ b/src/plugins/MatchStarter.ts
@@ -154,7 +154,7 @@ export class MatchStarter extends LobbyPlugin {
     let strSec = '';
 
     if (min > 1) {
-      strMin = min.toString() + ' minutes';
+      strMin = `${min.toString()} minutes`;
     } else if (min === 1) {
       strMin = '1 minute';
     }
@@ -164,7 +164,7 @@ export class MatchStarter extends LobbyPlugin {
     }
 
     if (sec > 1) {
-      strSec = sec.toString() + ' seconds';
+      strSec = `${sec.toString()} seconds`;
     } else if (sec === 1) {
       strSec = '1 second';
     }

--- a/src/plugins/MiscLoader.ts
+++ b/src/plugins/MiscLoader.ts
@@ -53,7 +53,7 @@ export class MiscLoader extends LobbyPlugin {
       if (!currentPlayer)
         return;
       if (currentPlayer.id === 0 || this.lobby.gameMode === undefined) {
-        this.lobby.SendMessageWithCoolTime('!stats ' + currentPlayer.name, '!rank', 10000);
+        this.lobby.SendMessageWithCoolTime(`!stats ${currentPlayer.name}`, '!rank', 10000);
         return;
       }
       let selectedMode = '';
@@ -73,7 +73,7 @@ export class MiscLoader extends LobbyPlugin {
       }
       const profile = await WebApiClient.getPlayer(currentPlayer.id, selectedMode);
 
-      const msg = profile.username + ' your rank is #' + profile.statistics.global_rank;
+      const msg = `${profile.username} your rank is #${profile.statistics.global_rank}`;
       this.lobby.SendMessageWithCoolTime(msg, '!rank', 5000);
 
     } catch (e: any) {

--- a/src/plugins/ProfileFecher.ts
+++ b/src/plugins/ProfileFecher.ts
@@ -61,13 +61,13 @@ export class ProfileFecher extends LobbyPlugin {
         if (profile !== null) {
           player.id = profile.id;
           player.profile = profile;
-          this.logger.info('fetch profile :' + player.name);
+          this.logger.info(`fetch profile :${player.name}`);
         } else {
-          this.logger.warn('user not found! ' + player.name);
+          this.logger.warn(`user not found! ${player.name}`);
         }
         this.pendingNames.delete(player.name);
       } catch (e) {
-        this.logger.error('@addTaskQueueIfNeeded' + e);
+        this.logger.error(`@addTaskQueueIfNeeded${e}`);
       }
 
     });

--- a/src/plugins/WordCounter.ts
+++ b/src/plugins/WordCounter.ts
@@ -104,7 +104,7 @@ export class WordCounter extends LobbyPlugin {
 
   private log(msg: string, important: boolean): void {
     const f = (important ? this.logger.info : this.logger.debug).bind(this.logger);
-    f('msg:%s', msg);
+    f(`msg:${msg}`);
     for (const p of this.periods) {
       f(`  ${p.symbol}(${(p.durationMs / 1000).toFixed(2)}sec) cp${p.symbol}:${p.chatsPerPeriod}(max:${p.chatsPerPeriodMax}), wp${p.symbol}:${p.wordsPerPeriod}(max:${p.wordsPerPeriodMax}) `);
     }

--- a/src/tests/AutoHostSelectorTest.ts
+++ b/src/tests/AutoHostSelectorTest.ts
@@ -1095,7 +1095,7 @@ describe('AutoHostSelectorTest', function () {
         assert.equal(DENY_LIST.players.size, 2);
 
         const un = 'asdf    hello';
-        tu.sendMessageAsOwner(lobby, '*denylist     add    ' + un);
+        tu.sendMessageAsOwner(lobby, `*denylist     add    ${un}`);
 
         assert.equal(DENY_LIST.players.size, 3);
         assert.include(DENY_LIST.players, escapeUserName(un));

--- a/src/tests/DummyIrcClientTest.ts
+++ b/src/tests/DummyIrcClientTest.ts
@@ -17,7 +17,7 @@ describe('DummyIrcClientTest', function () {
     //logIrcEvent(client);
     client.on('registered', function (message) {
       f_registered++;
-      client.say('BanchoBot', '!mp make ' + lobbyTitle);
+      client.say('BanchoBot', `!mp make ${lobbyTitle}`);
     });
     client.on('pm', function (nick, message) {
       const v = parser.ParseMpMakeResponse(nick, message);
@@ -50,7 +50,7 @@ describe('DummyIrcClientTest', function () {
 
     //logIrcEvent(client);
     client.on('registered', function (message) {
-      client.say('BanchoBot', '!mp make ' + lobbyTitle);
+      client.say('BanchoBot', `!mp make ${lobbyTitle}`);
     });
     client.on('join', function (channel, who) {
       players.forEach((v, i, a) => client.emulateAddPlayerAsync(v));
@@ -68,7 +68,7 @@ describe('DummyIrcClientTest', function () {
     //logIrcEvent(client);
     const lobbyTitle = '';
     client.on('registered', function (message) {
-      client.say('BanchoBot', '!mp make ' + lobbyTitle);
+      client.say('BanchoBot', `!mp make ${lobbyTitle}`);
     });
     client.on('pm', function (nick, message) {
       assert.equal(message, 'No name provided');
@@ -83,7 +83,7 @@ describe('DummyIrcClientTest', function () {
 
     //logIrcEvent(client);
     client.on('registered', function (message) {
-      client.say('BanchoBot', '!mp make ' + lobbyTitle);
+      client.say('BanchoBot', `!mp make ${lobbyTitle}`);
     });
     client.on('join', function (channel, who) {
       players.forEach((v, i, a) => client.emulateAddPlayerAsync(v));

--- a/src/tests/HostSkipperTest.ts
+++ b/src/tests/HostSkipperTest.ts
@@ -335,7 +335,7 @@ describe('HostSkipperTest', function () {
       let skipped = false;
       const task = resolveSkipAsync(lobby, () => skipped = true);
       for (let i = 1; i < numplayers; i++) {
-        ircClient.emulateMessage('p' + i, ircClient.channel, '!skip');
+        ircClient.emulateMessage(`p${i}`, ircClient.channel, '!skip');
         await tu.delayAsync(1);
         assert.equal(skipper.voting.count, Math.min(i, skipper.voting.required));
         assert.equal(skipped, skipper.voting.required <= i);
@@ -353,7 +353,7 @@ describe('HostSkipperTest', function () {
       const players = ['abc xxx[aaui]', 'a', 'b', 'c'];
       await tu.AddPlayersAsync(players, ircClient);
       await tu.changeHostAsync(players[0], lobby);
-      ircClient.emulateMessage(players[1], ircClient.channel, '!skip ' + players[0]);
+      ircClient.emulateMessage(players[1], ircClient.channel, `!skip ${players[0]}`);
       assert.equal(skipper.voting.count, 1);
     });
     it('accept !skip with space', async () => {

--- a/src/tests/IntegratedPluginsTest.ts
+++ b/src/tests/IntegratedPluginsTest.ts
@@ -41,7 +41,7 @@ describe('Integrated Plugins Tests', function () {
       await tu.delayAsync(10);
       tu.assertHost('p4', lobby);
 
-      m = '*skipto ' + owner.name;
+      m = `*skipto ${owner.name}`;
       assert.isTrue(parser.IsChatCommand(m));
       lobby.RaiseReceivedChatCommand(owner, m);
       await tu.delayAsync(10);

--- a/src/tests/LobbyTest.ts
+++ b/src/tests/LobbyTest.ts
@@ -452,7 +452,7 @@ describe('LobbyTest', function () {
       const { ircClient, lobby, players } = await PrepareLobbyWith3Players();
       let mf = false;
       const msg = () => {
-        return 'a' + 'b' + 'c';
+        return 'abc';
       };
       lobby.SentMessage.on(({ message }) => {
         assert.equal(message, msg());

--- a/src/tests/MatchStarterTest.ts
+++ b/src/tests/MatchStarterTest.ts
@@ -63,7 +63,7 @@ describe('MatchStarterTest', function () {
       for (let i = 1; i <= 16; i++) {
         const ex = Math.max(Math.ceil(i * starter.option.vote_rate), starter.option.vote_min);
         await tu.AddPlayersAsync(1, ircClient);
-        assert.equal(starter.voting.required, ex, 'players:' + i);
+        assert.equal(starter.voting.required, ex, `players:${i}`);
       }
     });
     it('vote test', async () => {

--- a/src/tests/TestUtils.ts
+++ b/src/tests/TestUtils.ts
@@ -28,7 +28,7 @@ class TestUtils {
       const start = client.players.size;
       const p = [];
       for (let i = 0; i < names; i++) {
-        p[i] = 'p' + (i + start);
+        p[i] = `p${i + start}`;
         await client.emulateAddPlayerAsync(p[i]);
       }
       return p;

--- a/src/trials/AppendersTrial.ts
+++ b/src/trials/AppendersTrial.ts
@@ -58,8 +58,8 @@ export async function trial() {
 async function test(interaction: GuildCommandInteraction) {
   const chatlogger = log4js.getLogger('chat');
   setDiscordId(interaction, chatlogger);
-  chatlogger.trace('%s:%s', 'user1', 'hello');
-  chatlogger.info('%s:%s', 'user2', 'hello');
+  chatlogger.trace('user1:hello');
+  chatlogger.info('user2:hello');
 
   const inout = log4js.getLogger('inout');
   setDiscordId(interaction, inout);

--- a/src/trials/BanchoIrcTrial.ts
+++ b/src/trials/BanchoIrcTrial.ts
@@ -8,15 +8,15 @@ export function trial() {
   const bot = new irc.Client(c.server, c.nick, c.opt);
 
   bot.on('error', function (message) {
-    console.error('ERROR: %s: %s', message.command, message.args.join(' '));
+    console.error(`ERROR: ${message.command}: ${message.args.join(' ')}`);
   });
 
   bot.on('message', function (from, to, message) {
-    console.log('%s => %s: %s', from, to, message);
+    console.log(`${from} => ${to}: ${message}`);
   });
 
   bot.on('pm', function (nick, message) {
-    console.log('Got private message from %s: %s', nick, message);
+    console.log(`Got private message from ${nick}: ${message}`);
     const v = parser.ParseMpMakeResponse(nick, message);
     if (v !== null) {
       console.log(`--- parsed pm id=${v.id} title=${v.title}`);
@@ -25,7 +25,7 @@ export function trial() {
 
   let is_joined = false;
   bot.on('join', function (channel, who) {
-    console.log('%s has joined %s', who, channel);
+    console.log(`${who} has joined ${channel}`);
     if (!is_joined) {
       is_joined = true;
       //bot.say(channel, "!mp password");
@@ -37,17 +37,17 @@ export function trial() {
 
   });
   bot.on('part', function (channel, who, reason) {
-    console.log('%s has left %s: %s', who, channel, reason);
+    console.log(`${who} has left ${channel}: ${reason}`);
   });
   bot.on('kick', function (channel, who, by, reason) {
-    console.log('%s was kicked from %s by %s: %s', who, channel, by, reason);
+    console.log(`${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
   bot.on('invite', (channel, from) => {
     console.log(`${from} invite you to ${channel}`);
   });
 
   bot.addListener('registered', function (message) {
-    console.log('registered %s', message);
+    console.log(`registered ${message}`);
     //bot.say("BanchoBot", "!mp make irc test lobby4");
     bot.join('#lobby');
   });

--- a/src/trials/BanchoIrcTrial.ts
+++ b/src/trials/BanchoIrcTrial.ts
@@ -59,12 +59,12 @@ export function ConnectionServerTrial() {
 
   logIrcEvent(bot);
 
-  console.log('hostmask => ' + bot.hostMask);
+  console.log(`hostmask => ${bot.hostMask}`);
 
   bot.connect();
 
   bot.addListener('registered', function (message) {
-    console.log('hostmask => ' + bot.hostMask);
+    console.log(`hostmask => ${bot.hostMask}`);
     bot.disconnect('goodby', () => { console.log('disconnected'); });
   });
 }

--- a/src/trials/DiscordTrial.ts
+++ b/src/trials/DiscordTrial.ts
@@ -28,7 +28,7 @@ export async function trial() {
   const cfg = config.get<DiscordOption>('Discord');
 
   client.once('ready', async cl => {
-    console.log('Ready! ' + generateInviteLink());
+    console.log(`Ready! ${generateInviteLink()}`);
     for (const g of cl.guilds.cache.values()) {
       await g.commands.set(commands);
     }
@@ -78,7 +78,7 @@ export async function trial() {
   });
 
   client.on('messageCreate', async message => {
-    console.log('msg:' + message.content);
+    console.log(`msg:${message.content}`);
 
     if (message.author.bot) {
       return;

--- a/src/trials/HistryTrial.ts
+++ b/src/trials/HistryTrial.ts
@@ -40,7 +40,7 @@ async function GetLobbyNameChanger() {
   const hr = new HistoryRepository(67719013, new HistoryFecher());
   let ln = '';
   hr.changedLobbyName.on(e => {
-    console.log(e.oldName + '->' + e.newName + ' ');
+    console.log(`${e.oldName}->${e.newName} `);
     ln = e.newName;
   });
   while (!ln.startsWith('4-5*')) {
@@ -52,21 +52,21 @@ async function promiseTrial() {
   let task = delayAsync(100).then(() => 1);
   setImmediate(async () => {
     const n = await task;
-    console.log('i1 ' + n);
+    console.log(`i1 ${n}`);
   });
   setImmediate(async () => {
     task = task.then(() => 2);
     const n = await task;
-    console.log('i2 ' + n);
+    console.log(`i2 ${n}`);
   });
   setImmediate(async () => {
     task = task.then(() => 3);
     const n = await task;
-    console.log('i3 ' + n);
+    console.log(`i3 ${n}`);
   });
   setImmediate(async () => {
     const n = await task;
-    console.log('i4 ' + n);
+    console.log(`i4 ${n}`);
   });
 }
 

--- a/src/trials/IrcTrial.ts
+++ b/src/trials/IrcTrial.ts
@@ -28,7 +28,7 @@ export function trial() {
     if (to.match(/^[#&]/)) {
       // channel message
       if (message.match(/hello/i)) {
-        bot.say(to, 'Hello there ' + from);
+        bot.say(to, `Hello there ${from}`);
       }
       if (message.match(/dance/)) {
         setTimeout(function () { bot.say(to, '\u0001ACTION dances: :D\\-<\u0001'); }, 1000);

--- a/src/trials/IrcTrial.ts
+++ b/src/trials/IrcTrial.ts
@@ -15,15 +15,15 @@ export function trial() {
   //bot.join(IrcTestSettings.channel);
 
   bot.addListener('error', function (message) {
-    console.error('ERROR: %s: %s', message.command, message.args.join(' '));
+    console.error(`ERROR: ${message.command}: ${message.args.join(' ')}`);
   });
 
   bot.addListener('message#blah', function (from, message) {
-    console.log('<%s> %s', from, message);
+    console.log(`<${from}> ${message}`);
   });
 
   bot.addListener('message', function (from, to, message) {
-    console.log('%s => %s: %s', from, to, message);
+    console.log(`${from} => ${to}: ${message}`);
 
     if (to.match(/^[#&]/)) {
       // channel message
@@ -43,20 +43,20 @@ export function trial() {
     }
   });
   bot.addListener('pm', function (nick, message) {
-    console.log('Got private message from %s: %s', nick, message);
+    console.log(`Got private message from ${nick}: ${message}`);
   });
   bot.addListener('join', function (channel, who) {
-    console.log('%s has joined %s', who, channel);
+    console.log(`${who} has joined ${channel}`);
   });
   bot.addListener('part', function (channel, who, reason) {
-    console.log('%s has left %s: %s', who, channel, reason);
+    console.log(`${who} has left ${channel}: ${reason}`);
   });
   bot.addListener('kick', function (channel, who, by, reason) {
-    console.log('%s was kicked from %s by %s: %s', who, channel, by, reason);
+    console.log(`${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
 
   bot.addListener('registered', function (message) {
-    console.log('registered %s', message);
+    console.log(`registered ${message}`);
     bot.join('#test');
   });
 }

--- a/src/trials/WebApiTrial.ts
+++ b/src/trials/WebApiTrial.ts
@@ -23,7 +23,7 @@ export async function getGuestTokenTrial(): Promise<void> {
   try {
     const response = await axios.post('https://osu.ppy.sh/oauth/token', {
       'grant_type': 'client_credentials',
-      'client_id': '' + oAuthConfig.client_id,
+      'client_id': `${oAuthConfig.client_id}`,
       'client_secret': oAuthConfig.client_secret,
       'scope': 'public'
     });
@@ -38,7 +38,7 @@ export async function getTokenTrial(): Promise<void> {
   try {
     const response = await axios.post('https://osu.ppy.sh/oauth/token', {
       'grant_type': 'authorization_code',
-      'client_id': '' + oAuthConfig.client_id,
+      'client_id': `${oAuthConfig.client_id}`,
       'client_secret': oAuthConfig.client_secret,
       'code': oAuthConfig.code,
       'redirect_uri': oAuthConfig.callback

--- a/src/trials/WebServerTrial.ts
+++ b/src/trials/WebServerTrial.ts
@@ -34,7 +34,7 @@ function startTestServer() {
     const p = `logs/cli/${req.params.id}.log`;
     let frm = 0;
     if (req.query.from) {
-      frm = parseInt(req.query.from + '');
+      frm = parseInt(`${req.query.from}`);
     }
     const stream = fs.createReadStream(p, { start: frm });
     const reader = readline.createInterface({ input: stream });

--- a/src/web/LogServer.ts
+++ b/src/web/LogServer.ts
@@ -24,7 +24,7 @@ export function startLogServer(port: number): Server {
     const p = `logs/cli/${req.params.id}.log`;
     let frm = 0;
     if (req.query.from) {
-      frm = parseInt(req.query.from + '');
+      frm = parseInt(`${req.query.from}`);
     }
     const stream = fs.createReadStream(p, { start: frm });
     const reader = readline.createInterface({ input: stream });
@@ -49,7 +49,7 @@ export function startLogServer(port: number): Server {
     const p = `logs/cli/${req.params.id}.log`;
     let frm = 0;
     if (req.query.from) {
-      frm = parseInt(req.query.from + '');
+      frm = parseInt(`${req.query.from}`);
     }
     fs.stat(p, (e, stats) => {
       if (e) {

--- a/src/web/statics/main.js
+++ b/src/web/statics/main.js
@@ -9,7 +9,7 @@
         if (c) yield c;
         c = b;
       } else if (c) {
-        c.message += '<br />' + l;
+        c.message += `<br />${l}`;
       }
     }
     if (c) yield c;
@@ -75,10 +75,10 @@
 
   function formatDate(date) {
     const M = date.getMonth() + 1;
-    const d = ('' + date.getDate()).padStart(2, '0');
-    const h = ('' + date.getHours()).padStart(2, '0');
-    const m = ('' + date.getMinutes()).padStart(2, '0');
-    const s = ('' + date.getSeconds()).padStart(2, '0');
+    const d = (`${date.getDate()}`).padStart(2, '0');
+    const h = (`${date.getHours()}`).padStart(2, '0');
+    const m = (`${date.getMinutes()}`).padStart(2, '0');
+    const s = (`${date.getSeconds()}`).padStart(2, '0');
     return `${M}/${d} ${h}:${m}:${s}`;
   }
 
@@ -98,8 +98,8 @@
     const spMsg = document.createElement('span');
     spMsg.className = 'message';
     spMsg.innerHTML = log.message;
-    li.classList.add('lvl_' + log.level);
-    li.classList.add('tag_' + log.tag);
+    li.classList.add(`lvl_${log.level}`);
+    li.classList.add(`tag_${log.tag}`);
 
     li.appendChild(spMsg);
     li.appendChild(spDate);
@@ -140,12 +140,12 @@
 
   function setMapId(mapId) {
     document.getElementsByName('mapid')[0].value = mapId;
-    document.location.search = 'mapid=' + mapId;
+    document.location.search = `mapid=${mapId}`;
   }
 
   function updateClicked() {
     const value = document.getElementsByName('mapid')[0].value;
-    document.location.search = 'mapid=' + value;
+    document.location.search = `mapid=${value}`;
   }
 
   function closeClicked() {
@@ -219,7 +219,7 @@
         fetchLogsAsync(mapId);
       });
       const his = document.getElementById('history');
-      his.href = 'https://osu.ppy.sh/community/matches/' + mapId;
+      his.href = `https://osu.ppy.sh/community/matches/${mapId}`;
       his.innerText = 'history';
     }
 

--- a/src/webapi/BeatmapRepository.ts
+++ b/src/webapi/BeatmapRepository.ts
@@ -164,7 +164,7 @@ export class WebsiteBeatmapFecher implements IBeatmapFetcher {
   webpreg = /<script id="json-beatmapset" type="application\/json">\s*(.+?)\s*<\/script>/ms;
   async fetchBeatmapFromWebsite(id: number): Promise<Beatmapset> {
     try {
-      const target = 'https://osu.ppy.sh/b/' + id;
+      const target = `https://osu.ppy.sh/b/${id}`;
       const res = await axios.get(target);
       const match = this.webpreg.exec(res.data);
       if (match) {

--- a/src/webapi/HistoryRepository.ts
+++ b/src/webapi/HistoryRepository.ts
@@ -89,9 +89,9 @@ export class HistoryRepository {
       while (!(await this.fetch(false)).filled && !this.lobbyClosed);
     } catch (e: any) {
       if (e instanceof Error) {
-        this.logger.error('@updateToLatest : ' + e.message);
+        this.logger.error(`@updateToLatest : ${e.message}`);
       } else {
-        this.logger.error('@updateToLatest : ' + e);
+        this.logger.error(`@updateToLatest : ${e}`);
       }
 
       this.hasError = true;
@@ -293,7 +293,7 @@ export class HistoryRepository {
           if (r.count === 0) break; // 結果が空なら終わり
           i = r.count - 1;
         } catch (e) {
-          this.logger.error('@calcCurrentOrderAsID - fetch : ' + e);
+          this.logger.error(`@calcCurrentOrderAsID - fetch : ${e}`);
           throw e;
         }
       }
@@ -331,7 +331,7 @@ export class HistoryRepository {
             }
             break;
           default:
-            this.logger.warn('unknown event type! ' + JSON.stringify(ev));
+            this.logger.warn(`unknown event type! ${JSON.stringify(ev)}`);
             break;
         }
       } else if (ev.detail.type === 'other' && ev.game) {
@@ -368,7 +368,7 @@ export class HistoryRepository {
         break;
       }
       if (HistoryRepository.LOOP_LIMIT < loopCount) {
-        this.logger.warn('loop limit exceeded! ' + HistoryRepository.LOOP_LIMIT);
+        this.logger.warn(`loop limit exceeded! ${HistoryRepository.LOOP_LIMIT}`);
         break;
       }
       if (this.lobbyClosed) {

--- a/src/webapi/ProfileRepository.ts
+++ b/src/webapi/ProfileRepository.ts
@@ -122,7 +122,7 @@ export class WebsiteProfileFetcher implements IProfileFetcher {
 
   async fetchProfileFromWebsite(userID: number, mode: string): Promise<UserProfile> {
     try {
-      const target = 'https://osu.ppy.sh/users/' + userID + '/' + mode;
+      const target = `https://osu.ppy.sh/users/${userID}/${mode}`;
       const res = await axios.get(target);
       const match = this.webpreg.exec(res.data);
       if (match) {

--- a/src/webapi/WebApiClient.ts
+++ b/src/webapi/WebApiClient.ts
@@ -75,10 +75,10 @@ class WebApiClientClass implements IBeatmapFetcher {
       const p = this.getTokenPath(token.isGuest);
       await fs.mkdir(path.dirname(p), { recursive: true });
       await fs.writeFile(p, JSON.stringify(token), { encoding: 'utf8', flag: 'w' });
-      this.logger.info('stored token to : ' + p);
+      this.logger.info(`stored token to : ${p}`);
       return true;
     } catch (e) {
-      this.logger.error('storeToken error : ' + e);
+      this.logger.error(`storeToken error : ${e}`);
       return false;
     }
   }
@@ -96,13 +96,13 @@ class WebApiClientClass implements IBeatmapFetcher {
       const j = await fs.readFile(p, 'utf8');
       const token = JSON.parse(j) as ApiToken;
       if (!isExpired(token)) {
-        this.logger.info('loaded stored token from : ' + p);
+        this.logger.info(`loaded stored token from : ${p}`);
         return token;
       }
       this.deleteStoredToken(asGuest);
       this.logger.info('deleted expired stored token');
     } catch (e) {
-      this.logger.error('loadStoredToken error : ' + e);
+      this.logger.error(`loadStoredToken error : ${e}`);
     }
   }
 
@@ -116,7 +116,7 @@ class WebApiClientClass implements IBeatmapFetcher {
     try {
       fs.unlink(p);
     } catch (e) {
-      this.logger.error('load token error : ' + e);
+      this.logger.error(`load token error : ${e}`);
     }
   }
 
@@ -124,7 +124,7 @@ class WebApiClientClass implements IBeatmapFetcher {
     try {
       const code = await this.getAuthorizeCode();
       const response = await axios.post('https://osu.ppy.sh/oauth/token', {
-        'client_id': '' + this.option.client_id,
+        'client_id': `${this.option.client_id}`,
         'client_secret': this.option.client_secret,
         'code': code,
         'grant_type': 'authorization_code',
@@ -156,8 +156,8 @@ class WebApiClientClass implements IBeatmapFetcher {
           res.end('missing code');
           return;
         }
-        res.end('ok : ' + code);
-        this.logger.trace('got code! ' + code);
+        res.end(`ok : ${code}`);
+        this.logger.trace(`got code! ${code}`);
         server.close(() => {
           this.logger.trace('closed callback');
         });
@@ -192,7 +192,7 @@ class WebApiClientClass implements IBeatmapFetcher {
     try {
       const response = await axios.post('https://osu.ppy.sh/oauth/token', {
         'grant_type': 'client_credentials',
-        'client_id': '' + this.option.client_id,
+        'client_id': `${this.option.client_id}`,
         'client_secret': this.option.client_secret,
         'scope': 'public'
       });


### PR DESCRIPTION
Closes #88

---
**Description**
Let's take it slowly.

If no longer wanted to keep those added ESLint rules, let me know.
Excluding the additions from the ESLint config it technically has `228+ additions and -228 deletions`

String concatetenation --> Template literals
Printf format strings --> Template literals

**Will**:
- Touch commented unused code(s)
- Add newline at end of affected files

**Will not**:
> These cases are not covered and is out of the scope of this PR.
- Change or correct grammatical errors
- Change formatting whitespaces
- Change formatting arrangements
- Remove anything unused

Since these are just a refactor, it shouldn't change or break functionality at all.

I hope that I did not overlook anything as I've carefully looked at how I refactored it, I minimized taking faster shortcuts that could be more prone to mistakes. I'll be self-reviewing the diff.

**Self-review status**:
*5/12/2022 5:51 PM*
I had finished reviewing 49 files.
Looks good to me.
I made the commits into small chunks, hoping it might help reviewers a bit.

**Testing**:
Compiles, no compilation errors from TypeScript
Boots up just fine just like it used to.

---

**Not applied**:
- Some considerable implicit -> explicit coercion notes. Mostly based on `String`.
Can be done implicitly, or explicitly to make it more obvious than it seems.
```ts
// example with string concatenation
const integer = -1;
// implicit
console.log('' + integer);
// explicit
console.log(String(integer));

// --------------------

// example with template literals
// implicit
console.log(`${integer}`);
// explicit
console.log(String(integer));
```
> The pull request is currently using the `implicit` example on `template literals`

- Coercion notes
```ts
// may not be included, !!v is readable enough
osu-ahr\src\libs\OptionValidator.ts
  32:12 `Boolean(v)`

osu-ahr\src\trials\WebApiTrial.ts
  26:20 `String(oAuthConfig.client_id)`
  41:20 `String(oAuthConfig.client_id)`   

osu-ahr\src\trials\WebServerTrial.ts
  37:22 `String(req.query.from)`

osu-ahr\src\web\LogServer.ts
  27:22 `String(req.query.from)`
  52:22 `String(req.query.from)`

osu-ahr\src\web\statics\main.js
  78:16 `String(date.getDate())`
  79:16 `String(date.getHours())`
  80:16 `String(date.getMinutes())`
  81:16 `String(date.getSeconds())`

osu-ahr\src\webapi\WebApiClient.ts
  127:22  `String(this.option.client_id)`    
  195:22  `String(this.option.client_id)`
```