### PR TITLE
refactor: deliberate use of error properties

### DIFF
--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -61,7 +61,7 @@ export class OahrCli extends OahrBase {
               await this.makeLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
             } catch (e: any) {
-              logger.info(`Failed to make a lobby :\n${e.message}\n${e.stack}`);
+              logger.info(`Failed to make a lobby :\n${e}`);
               this.scene = this.scenes.exited;
             }
             break;
@@ -75,7 +75,7 @@ export class OahrCli extends OahrBase {
               await this.enterLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
             } catch (e: any) {
-              logger.info(`Invalid channel :\n${e.message}\n${e.stack}`);
+              logger.info(`Invalid channel :\n${e}`);
               this.scene = this.scenes.exited;
             }
             break;

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -60,8 +60,8 @@ export class OahrCli extends OahrBase {
             try {
               await this.makeLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
-            } catch (e) {
-              logger.info(`Failed to make a lobby : ${e}`);
+            } catch (e: any) {
+              logger.info(`Failed to make a lobby :\n${e.message}\n${e.stack}`);
               this.scene = this.scenes.exited;
             }
             break;
@@ -74,8 +74,8 @@ export class OahrCli extends OahrBase {
               }
               await this.enterLobbyAsync(l.arg);
               this.transitionToLobbyMenu();
-            } catch (e) {
-              logger.info(`Invalid channel : ${e}`);
+            } catch (e: any) {
+              logger.info(`Invalid channel :\n${e.message}\n${e.stack}`);
               this.scene = this.scenes.exited;
             }
             break;

--- a/src/cli/OahrHeadless.ts
+++ b/src/cli/OahrHeadless.ts
@@ -26,8 +26,8 @@ export class OahrHeadless extends OahrBase {
         default:
           process.exit(1);
       }
-    } catch (e) {
-      logger.error(e);
+    } catch (e: any) {
+      logger.error(`\n${e.message}\n${e.stack}`);
       process.exit(1);
     }
 

--- a/src/cli/OahrHeadless.ts
+++ b/src/cli/OahrHeadless.ts
@@ -27,7 +27,7 @@ export class OahrHeadless extends OahrBase {
           process.exit(1);
       }
     } catch (e: any) {
-      logger.error(`\n${e.message}\n${e.stack}`);
+      logger.error(`\n${e}`);
       process.exit(1);
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,6 @@ try {
     oahr.start(null);
   }
 } catch (e: any) {
-  logger.error(`\n${e.message}\n${e.stack}`);
+  logger.error(`\n${e}`);
   process.exit(1);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,6 @@ try {
     oahr.start(null);
   }
 } catch (e: any) {
-  logger.error(e);
+  logger.error(`\n${e.message}\n${e.stack}`);
   process.exit(1);
 }

--- a/src/discord/DiscordAppender.ts
+++ b/src/discord/DiscordAppender.ts
@@ -41,7 +41,7 @@ export function configure(config: any, layouts: any) {
           await ch.send(content);
         }
       } catch (e: any) {
-        logger.error(e.message);
+        logger.error(`\n${e.message}\n${e.stack}`);
         const ahr = ahrs[loggingEvent.context.channelId];
         if (ahr) {
           ahr.stopTransferLog();

--- a/src/discord/DiscordBot.ts
+++ b/src/discord/DiscordBot.ts
@@ -90,7 +90,7 @@ export class DiscordBot {
         logger.error('Check the setup guide -> https://github.com/Meowhal/osu-ahr#discord-integration');
 
       } else {
-        logger.error(e);
+        logger.error(`\n${e.message}\n${e.stack}`);
       }
       process.exit();
     }
@@ -154,7 +154,7 @@ export class DiscordBot {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.makeLobbyAsync(name);
     } catch (e: any) {
-      logger.error(`couldn't make a tournament lobby. ${e}`);
+      logger.error(`couldn't make a tournament lobby.\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 couldn't make a tournament lobby. ${e.message}`);
       ahr?.lobby.destroy();
       return;
@@ -166,7 +166,7 @@ export class DiscordBot {
       await this.updateMatchSummary(ahr);
       await interaction.editReply(`😀 Created the lobby [Lobby History](https://osu.ppy.sh/mp/${lobbyNumber})`);
     } catch (e: any) {
-      logger.error(`couldn't make a discord channel. ${e}`);
+      logger.error(`couldn't make a discord channel.\n${e.message}\n${e.stack}`);
       await interaction.editReply(`couldn't make a discord channel. ${e.message}`);
     }
   }
@@ -197,8 +197,8 @@ export class DiscordBot {
     try {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.enterLobbyAsync(lobbyId);
-    } catch (e) {
-      logger.error(`couldn't enter the tournament lobby. ${e}`);
+    } catch (e: any) {
+      logger.error(`couldn't enter the tournament lobby.\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 couldn't enter the tournament lobby. ${e}`);
       ahr?.lobby.destroy();
       return;
@@ -213,8 +213,8 @@ export class DiscordBot {
       }
       await this.updateMatchSummary(ahr);
       await interaction.editReply(`😀 Entered the lobby [Lobby History](https://osu.ppy.sh/mp/${lobbyNumber})`);
-    } catch (e) {
-      logger.error(`couldn't make a discord channel.  ${e}`);
+    } catch (e: any) {
+      logger.error(`couldn't make a discord channel.\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 couldn't make a discord channel.  ${e}`);
     }
   }
@@ -243,7 +243,7 @@ export class DiscordBot {
     try {
       await interaction.editReply({ embeds: [ahr.createDetailInfoEmbed()] });
     } catch (e: any) {
-      logger.error(`@discordbot.info ${e}`);
+      logger.error(`@discordbot.info\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 error! ${e.message}`);
     }
   }
@@ -286,8 +286,8 @@ export class DiscordBot {
     try {
       await ahr.lobby.CloseLobbyAsync();
       await interaction.editReply('Closed the lobby');
-    } catch (e) {
-      logger.error(`@discordbot.close ${e}`);
+    } catch (e: any) {
+      logger.error(`@discordbot.close\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 error! ${e}`);
     }
   }
@@ -308,8 +308,8 @@ export class DiscordBot {
     try {
       await ahr.lobby.QuitLobbyAsync();
       await interaction.editReply('Stopped managing the lobby');
-    } catch (e) {
-      logger.error(`@discordbot.quit ${e}`);
+    } catch (e: any) {
+      logger.error(`@discordbot.quit\n${e.message}\n${e.stack}`);
       await interaction.editReply(`😫 error! ${e}`);
     }
   }
@@ -343,8 +343,8 @@ export class DiscordBot {
           break;
       }
       await this.updateMatchSummary(ahr);
-    } catch (e) {
-      logger.error(`@handleButtonInteraction ${e}`);
+    } catch (e: any) {
+      logger.error(`@handleButtonInteraction\n${e.message}\n${e.stack}`);
     }
   }
 
@@ -518,7 +518,7 @@ export class DiscordBot {
           return;
         }
       }
-      logger.error(e);
+      logger.error(`\n${e.message}\n${e.stack}`);
       ahr.updateSummaryMessage = false;
     }
   }
@@ -545,7 +545,7 @@ export class DiscordBot {
         await message.delete();
       }
     } catch (e: any) {
-      logger.error(e);
+      logger.error(`\n${e.message}\n${e.stack}`);
     }
   }
 }

--- a/src/discord/DiscordBot.ts
+++ b/src/discord/DiscordBot.ts
@@ -155,7 +155,7 @@ export class DiscordBot {
       await ahr.makeLobbyAsync(name);
     } catch (e: any) {
       logger.error(`couldn't make a tournament lobby.\n${e}`);
-      await interaction.editReply(`😫 couldn't make a tournament lobby. ${e.message}`);
+      await interaction.editReply(`😫 couldn't make a tournament lobby. ${e}`);
       ahr?.lobby.destroy();
       return;
     }

--- a/src/discord/DiscordBot.ts
+++ b/src/discord/DiscordBot.ts
@@ -154,7 +154,7 @@ export class DiscordBot {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.makeLobbyAsync(name);
     } catch (e: any) {
-      logger.error(`couldn't make a tournament lobby.\n${e.message}\n${e.stack}`);
+      logger.error(`couldn't make a tournament lobby.\n${e}`);
       await interaction.editReply(`😫 couldn't make a tournament lobby. ${e.message}`);
       ahr?.lobby.destroy();
       return;
@@ -198,7 +198,7 @@ export class DiscordBot {
       ahr = new OahrDiscord(this.ircClient, this.sharedObjects);
       await ahr.enterLobbyAsync(lobbyId);
     } catch (e: any) {
-      logger.error(`couldn't enter the tournament lobby.\n${e.message}\n${e.stack}`);
+      logger.error(`couldn't enter the tournament lobby.\n${e}`);
       await interaction.editReply(`😫 couldn't enter the tournament lobby. ${e}`);
       ahr?.lobby.destroy();
       return;
@@ -287,7 +287,7 @@ export class DiscordBot {
       await ahr.lobby.CloseLobbyAsync();
       await interaction.editReply('Closed the lobby');
     } catch (e: any) {
-      logger.error(`@discordbot.close\n${e.message}\n${e.stack}`);
+      logger.error(`@discordbot.close\n${e}`);
       await interaction.editReply(`😫 error! ${e}`);
     }
   }
@@ -309,7 +309,7 @@ export class DiscordBot {
       await ahr.lobby.QuitLobbyAsync();
       await interaction.editReply('Stopped managing the lobby');
     } catch (e: any) {
-      logger.error(`@discordbot.quit\n${e.message}\n${e.stack}`);
+      logger.error(`@discordbot.quit\n${e}`);
       await interaction.editReply(`😫 error! ${e}`);
     }
   }

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -41,6 +41,6 @@ try {
   const bot = new DiscordBot(ircClient, discordClient);
   bot.start();
 } catch (e: any) {
-  logger.error(e);
+  logger.error(`\n${e.message}\n${e.stack}`);
   process.exit(1);
 }

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -41,6 +41,6 @@ try {
   const bot = new DiscordBot(ircClient, discordClient);
   bot.start();
 } catch (e: any) {
-  logger.error(`\n${e.message}\n${e.stack}`);
+  logger.error(`\n${e}`);
   process.exit(1);
 }

--- a/src/plugins/CacheCleaner.ts
+++ b/src/plugins/CacheCleaner.ts
@@ -73,8 +73,8 @@ export class CacheCleaner extends LobbyPlugin {
       this.logger.info(`heap size: ${this.formatByte(this.lastHeapSize)} -> ${this.formatByte(currentMem)}`);
       this.lastHeapSize = currentMem;
       this.cleanedAt = Date.now();
-    } catch (e) {
-      this.logger.error(e);
+    } catch (e: any) {
+      this.logger.error(`\n${e.message}\n${e.stack}`);
     }
   }
 

--- a/src/plugins/LobbyKeeper.ts
+++ b/src/plugins/LobbyKeeper.ts
@@ -269,7 +269,7 @@ export class LobbyKeeper extends LobbyPlugin {
       }
 
     } catch (e: any) {
-      this.logger.error(`@LobbyKeeper#onParsedSettings ${e?.message}`);
+      this.logger.error(`@LobbyKeeper#onParsedSettings\n${e?.message}\n${e?.stack}`);
     }
   }
 

--- a/src/plugins/LobbyPlugin.ts
+++ b/src/plugins/LobbyPlugin.ts
@@ -49,8 +49,8 @@ export class LobbyPlugin {
   loadEnvSettings(option: any) {
     try {
       loadEnvConfig(this.pluginName, option);
-    } catch (e) {
-      this.logger.error(e);
+    } catch (e: any) {
+      this.logger.error(`\n${e.message}\n${e.stack}`);
       process.exit(1);
     }
   }

--- a/src/plugins/MapChecker.ts
+++ b/src/plugins/MapChecker.ts
@@ -153,7 +153,7 @@ export class MapChecker extends LobbyPlugin {
         this.logger.info(m);
       }
     } catch (e: any) {
-      this.logger.warn(e.message);
+      this.logger.warn(`\n${e.message}\n${e.stack}`);
     }
   }
 
@@ -221,7 +221,7 @@ export class MapChecker extends LobbyPlugin {
             break;
         }
       } else {
-        this.logger.error(`unexpected error. checking:${mapId}, err:${e.message}`);
+        this.logger.error(`unexpected error. checking:${mapId}, err:\n${e.message}\n${e.stack}`);
       }
     }
   }

--- a/src/plugins/MiscLoader.ts
+++ b/src/plugins/MiscLoader.ts
@@ -87,7 +87,7 @@ export class MiscLoader extends LobbyPlugin {
             break;
         }
       } else {
-        this.logger.error(`unexpected error. checking:${player.id}, err:${e.message}`);
+        this.logger.error(`unexpected error. checking:${player.id}, err:\n${e.message}\n${e.stack}`);
       }
     }
   }
@@ -124,7 +124,7 @@ export class MiscLoader extends LobbyPlugin {
             break;
         }
       } else {
-        this.logger.error(`unexpected error. checking:${mapId}, err:${e.message}`);
+        this.logger.error(`unexpected error. checking:${mapId}, err:\n${e.message}\n${e.stack}`);
       }
     }
   }

--- a/src/plugins/ProfileFecher.ts
+++ b/src/plugins/ProfileFecher.ts
@@ -66,8 +66,8 @@ export class ProfileFecher extends LobbyPlugin {
           this.logger.warn(`user not found! ${player.name}`);
         }
         this.pendingNames.delete(player.name);
-      } catch (e) {
-        this.logger.error(`@addTaskQueueIfNeeded${e}`);
+      } catch (e: any) {
+        this.logger.error(`@addTaskQueueIfNeeded\n${e.message}\n${e.stack}`);
       }
 
     });

--- a/src/trials/WebApiTrial.ts
+++ b/src/trials/WebApiTrial.ts
@@ -29,8 +29,8 @@ export async function getGuestTokenTrial(): Promise<void> {
     });
     const c = response.data;
     console.log(c);
-  } catch (e) {
-    console.error(e);
+  } catch (e: any) {
+    console.error(`\n${e.message}\n${e.stack}`);
   }
 }
 
@@ -45,8 +45,8 @@ export async function getTokenTrial(): Promise<void> {
     });
     const c = response.data;
     console.log(c);
-  } catch (e) {
-    console.error(e);
+  } catch (e: any) {
+    console.error(`\n${e.message}\n${e.stack}`);
   }
 }
 
@@ -63,7 +63,7 @@ export async function fetchUpdateTrial(): Promise<void> {
     const r = await axios.get('https://osu.ppy.sh/community/chat/updates?since=2065115911');
     const c = r.data;
     console.log(c);
-  } catch (e) {
-    console.error(e);
+  } catch (e: any) {
+    console.error(`\n${e.message}\n${e.stack}`);
   }
 }

--- a/src/webapi/HistoryRepository.ts
+++ b/src/webapi/HistoryRepository.ts
@@ -91,7 +91,7 @@ export class HistoryRepository {
       if (e instanceof Error) {
         this.logger.error(`@updateToLatest : ${e.message}`);
       } else {
-        this.logger.error(`@updateToLatest : ${e}`);
+        this.logger.error(`@updateToLatest :\n${e.message}\n${e.stack}`);
       }
 
       this.hasError = true;
@@ -292,8 +292,8 @@ export class HistoryRepository {
           const r = await this.fetch(true);
           if (r.count === 0) break; // 結果が空なら終わり
           i = r.count - 1;
-        } catch (e) {
-          this.logger.error(`@calcCurrentOrderAsID - fetch : ${e}`);
+        } catch (e: any) {
+          this.logger.error(`@calcCurrentOrderAsID - fetch :\n${e.message}\n${e.stack}`);
           throw e;
         }
       }

--- a/src/webapi/WebApiClient.ts
+++ b/src/webapi/WebApiClient.ts
@@ -77,7 +77,7 @@ class WebApiClientClass implements IBeatmapFetcher {
       await fs.writeFile(p, JSON.stringify(token), { encoding: 'utf8', flag: 'w' });
       this.logger.info(`stored token to : ${p}`);
       return true;
-    } catch (e) {
+    } catch (e: any) {
       this.logger.error(`storeToken error :\n${e.message}\n${e.stack}`);
       return false;
     }

--- a/src/webapi/WebApiClient.ts
+++ b/src/webapi/WebApiClient.ts
@@ -78,7 +78,7 @@ class WebApiClientClass implements IBeatmapFetcher {
       this.logger.info(`stored token to : ${p}`);
       return true;
     } catch (e) {
-      this.logger.error(`storeToken error : ${e}`);
+      this.logger.error(`storeToken error :\n${e.message}\n${e.stack}`);
       return false;
     }
   }
@@ -101,8 +101,8 @@ class WebApiClientClass implements IBeatmapFetcher {
       }
       this.deleteStoredToken(asGuest);
       this.logger.info('deleted expired stored token');
-    } catch (e) {
-      this.logger.error(`loadStoredToken error : ${e}`);
+    } catch (e: any) {
+      this.logger.error(`loadStoredToken error :\n${e.message}\n${e.stack}`);
     }
   }
 
@@ -115,8 +115,8 @@ class WebApiClientClass implements IBeatmapFetcher {
     }
     try {
       fs.unlink(p);
-    } catch (e) {
-      this.logger.error(`load token error : ${e}`);
+    } catch (e: any) {
+      this.logger.error(`load token error :\n${e.message}\n${e.stack}`);
     }
   }
 
@@ -134,8 +134,8 @@ class WebApiClientClass implements IBeatmapFetcher {
       response.data.expires_in += Date.now() / 1000;
       this.logger.info('get Authorized token');
       return response.data;
-    } catch (e) {
-      this.logger.error(`getAuthorizedToken error : ${e}`);
+    } catch (e: any) {
+      this.logger.error(`getAuthorizedToken error :\n${e.message}\n${e.stack}`);
     }
   }
 
@@ -199,8 +199,8 @@ class WebApiClientClass implements IBeatmapFetcher {
       response.data.isGuest = true;
       response.data.expires_in += Date.now() / 1000;
       return response.data;
-    } catch (e) {
-      this.logger.error(`getGuestToken error : ${e}`);
+    } catch (e: any) {
+      this.logger.error(`getGuestToken error :\n${e.message}\n${e.stack}`);
     }
   }
 


### PR DESCRIPTION
Closes #89

---
### Will:
- Remove some extra whitespaces in between strings or statements to make room for the `\n`
- Add `\n` infront as baseline for `logger.error` and `console.error` for preparation
- Mostly touch `logger.error`s, some few `console.error`s
- Explicitly add `any` type on some catch clauses that dont have it, for now

### Will not:
> Out of the scope of this pr, this will not be applied, will all be done by #90
- Correct typos or statements

### Will never:
> The changes will never be applied on these, they're not to be included within the changes.
- Touch intentionally handled errors
- Touch the tests folder
> Every `try/catch` on `tests` folder will remain as is for I think errors are not supposed to be logged there.

Sometimes, I saw that some statements were wrapped in `try/catch` but only then just for the error to be thrown again, I left them as is.

Minimized used of automation or refactoring tools since they're inefficient for something like this and can be more prone to mistakes.

Most were refactored manually.

**Self-review Status**
*5/13/2022 1:07 PM*
I had finished reviewing 15 files.
Looks good to me.

**Testing**
Compiles