### PR TITLE
refactor: proper usage of exempli gratia

### DIFF
--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -9,8 +9,8 @@ const logger = log4js.getLogger('cli');
 
 const mainMenuCommandsMessage = `
 MainMenu Commands
-  [make <Lobby_name>] Make a lobby. ex: 'make 5* auto host rotation'
-  [enter <LobbyID>] Enter a lobby. ex: 'enter 123456' (It will only work with a tournament lobby ID.)
+  [make <Lobby_name>] Make a lobby, e.g.: 'make 5* auto host rotation'
+  [enter <LobbyID>] Enter a lobby, e.g: 'enter 123456' (It will only work with a tournament lobby ID.)
   [help] Show this message.
   [quit] Quit this application.
 `;
@@ -19,8 +19,8 @@ const lobbyMenuCommandsMessage = `
 LobbyMenu Commands
   [say <Message>] Send a message to #multiplayer.
   [info] Show the application's current information.
-  [reorder] Arrange the host queue. ex: 'reorder player1, player2, player3'
-  [regulation <regulation command>] Change one or more regulations. ex: 'regulation star_min=2 star_max=5 len_min=60 len_max=300' 
+  [reorder] Arrange the host queue, e.g: 'reorder player1, player2, player3'
+  [regulation <regulation command>] Change one or more regulations, e.g: 'regulation star_min=2 star_max=5 len_min=60 len_max=300' 
   [regulation enable] Enable regulation checking.
   [regulation disable] Disable regulation checking.
   [close] Close the lobby when everyone leaves.
@@ -54,7 +54,7 @@ export class OahrCli extends OahrBase {
           case 'm':
           case 'make':
             if (l.arg === '') {
-              logger.info('Make command needs a lobby name. ex: \'make testlobby\'');
+              logger.info('Make command needs a lobby name, e.g: \'make testlobby\'');
               return;
             }
             try {
@@ -69,7 +69,7 @@ export class OahrCli extends OahrBase {
           case 'enter':
             try {
               if (l.arg === '') {
-                logger.info('Enter command needs a lobby ID. ex: \'enter 123456\'');
+                logger.info('Enter command needs a lobby ID, e.g: \'enter 123456\'');
                 return;
               }
               await this.enterLobbyAsync(l.arg);

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -10,7 +10,7 @@ const logger = log4js.getLogger('cli');
 const mainMenuCommandsMessage = `
 MainMenu Commands
   [make <Lobby_name>] Make a lobby, e.g.: 'make 5* auto host rotation'
-  [enter <LobbyID>] Enter a lobby, e.g: 'enter 123456' (It will only work with a tournament lobby ID.)
+  [enter <LobbyID>] Enter a lobby, e.g.: 'enter 123456' (It will only work with a tournament lobby ID.)
   [help] Show this message.
   [quit] Quit this application.
 `;
@@ -19,8 +19,8 @@ const lobbyMenuCommandsMessage = `
 LobbyMenu Commands
   [say <Message>] Send a message to #multiplayer.
   [info] Show the application's current information.
-  [reorder] Arrange the host queue, e.g: 'reorder player1, player2, player3'
-  [regulation <regulation command>] Change one or more regulations, e.g: 'regulation star_min=2 star_max=5 length_min=60 length_max=300' 
+  [reorder] Arrange the host queue, e.g.: 'reorder player1, player2, player3'
+  [regulation <regulation command>] Change one or more regulations, e.g.: 'regulation star_min=2 star_max=5 length_min=60 length_max=300' 
   [regulation enable] Enable regulation checking.
   [regulation disable] Disable regulation checking.
   [close] Close the lobby when everyone leaves.
@@ -54,7 +54,7 @@ export class OahrCli extends OahrBase {
           case 'm':
           case 'make':
             if (l.arg === '') {
-              logger.info('Make command needs a lobby name, e.g: \'make testlobby\'');
+              logger.info('Make command needs a lobby name, e.g.: \'make testlobby\'');
               return;
             }
             try {
@@ -69,7 +69,7 @@ export class OahrCli extends OahrBase {
           case 'enter':
             try {
               if (l.arg === '') {
-                logger.info('Enter command needs a lobby ID, e.g: \'enter 123456\'');
+                logger.info('Enter command needs a lobby ID, e.g.: \'enter 123456\'');
                 return;
               }
               await this.enterLobbyAsync(l.arg);

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -20,7 +20,7 @@ LobbyMenu Commands
   [say <Message>] Send a message to #multiplayer.
   [info] Show the application's current information.
   [reorder] Arrange the host queue, e.g: 'reorder player1, player2, player3'
-  [regulation <regulation command>] Change one or more regulations, e.g: 'regulation star_min=2 star_max=5 len_min=60 len_max=300' 
+  [regulation <regulation command>] Change one or more regulations, e.g: 'regulation star_min=2 star_max=5 length_min=60 length_max=300' 
   [regulation enable] Enable regulation checking.
   [regulation disable] Disable regulation checking.
   [close] Close the lobby when everyone leaves.

--- a/src/cli/OahrCli.ts
+++ b/src/cli/OahrCli.ts
@@ -9,8 +9,8 @@ const logger = log4js.getLogger('cli');
 
 const mainMenuCommandsMessage = `
 MainMenu Commands
-  [make <Lobby_name>] Make a lobby, e.g.: 'make 5* auto host rotation'
-  [enter <LobbyID>] Enter a lobby, e.g.: 'enter 123456' (It will only work with a tournament lobby ID.)
+  [make <Lobby_name>] Make a lobby, e.g., 'make 5* auto host rotation'
+  [enter <LobbyID>] Enter a lobby, e.g., 'enter 123456' (It will only work with a tournament lobby ID.)
   [help] Show this message.
   [quit] Quit this application.
 `;
@@ -19,8 +19,8 @@ const lobbyMenuCommandsMessage = `
 LobbyMenu Commands
   [say <Message>] Send a message to #multiplayer.
   [info] Show the application's current information.
-  [reorder] Arrange the host queue, e.g.: 'reorder player1, player2, player3'
-  [regulation <regulation command>] Change one or more regulations, e.g.: 'regulation star_min=2 star_max=5 length_min=60 length_max=300' 
+  [reorder] Arrange the host queue, e.g., 'reorder player1, player2, player3'
+  [regulation <regulation command>] Change one or more regulations, e.g., 'regulation star_min=2 star_max=5 length_min=60 length_max=300' 
   [regulation enable] Enable regulation checking.
   [regulation disable] Disable regulation checking.
   [close] Close the lobby when everyone leaves.
@@ -54,7 +54,7 @@ export class OahrCli extends OahrBase {
           case 'm':
           case 'make':
             if (l.arg === '') {
-              logger.info('Make command needs a lobby name, e.g.: \'make testlobby\'');
+              logger.info('Make command needs a lobby name, e.g., \'make testlobby\'');
               return;
             }
             try {
@@ -69,7 +69,7 @@ export class OahrCli extends OahrBase {
           case 'enter':
             try {
               if (l.arg === '') {
-                logger.info('Enter command needs a lobby ID, e.g.: \'enter 123456\'');
+                logger.info('Enter command needs a lobby ID, e.g., \'enter 123456\'');
                 return;
               }
               await this.enterLobbyAsync(l.arg);

--- a/src/discord/BotCommand.ts
+++ b/src/discord/BotCommand.ts
@@ -10,7 +10,7 @@ export const BotCommands: ApplicationCommandData[] = [
       {
         type: 3,
         name: 'lobby_name',
-        description: 'The initial lobby name that\'ll be set. E.g. "4.00-5.99 auto host rotation"',
+        description: 'The initial lobby name that\'ll be set, e.g., "4.00-5.99 auto host rotation"',
         required: true
       }
     ]


### PR DESCRIPTION
**Description**
Properly use `e.g.` (exempli gratia) for examples, instead of using `Ex.` because `Ex.` could mean other things.

Also corrects a minor regulation example typo.