### PR TITLE
refactor(src#IIrcClient): improve texts and error messages

### DIFF
--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -22,7 +22,7 @@ export interface IIrcClient extends EventEmitter {
 
 export function logIrcEvent(client: IIrcClient) {
   client.on('error', function (message) {
-    ircLogger.error(`@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
+    ircLogger.error(`@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${message instanceof Object && JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;

--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -22,38 +22,38 @@ export interface IIrcClient extends EventEmitter {
 
 export function logIrcEvent(client: IIrcClient) {
   client.on('error', function (message) {
-    ircLogger.error(`ERROR:\n${JSON.stringify(message)}\n${JSON.stringify(message.stack)}\n${message}\n${message.stack}`);
+    ircLogger.error(`@IIrcClient#logIrcEvent:@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;
-    ircLogger.debug(`@reg ${args?.join(', ')}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#registered\n${args?.join(', ')}`);
   });
   client.on('message', function (from, to, message) {
-    ircLogger.debug(`@msg  ${from} => ${to}: ${message}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#message\n${from} => ${to}: ${message}`);
   });
   client.on('pm', function (nick, message) {
-    ircLogger.debug(`@pm   ${nick}: ${message}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#pm\n${nick}: ${message}`);
   });
   client.on('join', function (channel, who) {
-    ircLogger.debug(`@join ${who} has joined ${channel}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#join\n${who} has joined ${channel}`);
   });
   client.on('part', function (channel, who, reason) {
-    ircLogger.debug(`@part ${who} has left ${channel}: ${reason}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#part\n${who} has left ${channel}: ${reason}`);
   });
   client.on('kick', function (channel, who, by, reason) {
-    ircLogger.debug(`@kick ${who} was kicked from ${channel} by ${by}: ${reason}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#kick\n${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
   client.on('invite', (channel, from) => {
-    ircLogger.debug(`@invt ${from} invite you to ${channel}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#invite\n${from} invited you to ${channel}`);
   });
   client.on('notice', function (from, to, message) {
-    ircLogger.debug(`@notice  ${from} => ${to}: ${message}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#notice\n${from} => ${to}: ${message}`);
   });
   client.on('action', function (from, to, text, message) {
-    ircLogger.debug(`@action  ${from} => ${to}: ${text}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#action\n${from} => ${to}: ${text}`);
   });
   client.on('selfMessage', (target: string, toSend) => {
-    ircLogger.debug(`@sent bot => ${target}: ${toSend}`);
+    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#selfMessage\nBot => ${target}: ${toSend}`);
   });
 }
 
@@ -61,9 +61,9 @@ export function logPrivateMessage(client: IIrcClient) {
   client.on('message', (from, to, message) => {
     if (to === client.nick) {
       if (IsStatResponse(message)) {
-        pmLogger.trace(`pm ${from} -> ${message}`);
+        pmLogger.trace(`@IIrcClient#logPrivateMessage:@NodeIRC#message\nPM: ${from} -> ${message}`);
       } else {
-        pmLogger.info(`pm ${from} -> ${message}`);
+        pmLogger.info(`@IIrcClient#logPrivateMessage:@NodeIRC#message\nPM: ${from} -> ${message}`);
       }
     }
   });

--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -22,38 +22,38 @@ export interface IIrcClient extends EventEmitter {
 
 export function logIrcEvent(client: IIrcClient) {
   client.on('error', function (message) {
-    ircLogger.error(`@IIrcClient#logIrcEvent:@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
+    ircLogger.error(`@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#registered\n${args?.join(', ')}`);
+    ircLogger.debug(`@NodeIRC#registered\n${args?.join(', ')}`);
   });
   client.on('message', function (from, to, message) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#message\n${from} => ${to}: ${message}`);
+    ircLogger.debug(`@NodeIRC#message\n${from} => ${to}: ${message}`);
   });
   client.on('pm', function (nick, message) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#pm\n${nick}: ${message}`);
+    ircLogger.debug(`@NodeIRC#pm\n${nick}: ${message}`);
   });
   client.on('join', function (channel, who) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#join\n${who} has joined ${channel}`);
+    ircLogger.debug(`@NodeIRC#join\n${who} has joined ${channel}`);
   });
   client.on('part', function (channel, who, reason) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#part\n${who} has left ${channel}: ${reason}`);
+    ircLogger.debug(`@NodeIRC#part\n${who} has left ${channel}: ${reason}`);
   });
   client.on('kick', function (channel, who, by, reason) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#kick\n${who} was kicked from ${channel} by ${by}: ${reason}`);
+    ircLogger.debug(`@NodeIRC#kick\n${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
   client.on('invite', (channel, from) => {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#invite\n${from} invited you to ${channel}`);
+    ircLogger.debug(`@NodeIRC#invite\n${from} invited you to ${channel}`);
   });
   client.on('notice', function (from, to, message) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#notice\n${from} => ${to}: ${message}`);
+    ircLogger.debug(`@NodeIRC#notice\n${from} => ${to}: ${message}`);
   });
   client.on('action', function (from, to, text, message) {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#action\n${from} => ${to}: ${text}`);
+    ircLogger.debug(`@NodeIRC#action\n${from} => ${to}: ${text}`);
   });
   client.on('selfMessage', (target: string, toSend) => {
-    ircLogger.debug(`@IIrcClient#logIrcEvent:@NodeIRC#selfMessage\nBot => ${target}: ${toSend}`);
+    ircLogger.debug(`@NodeIRC#selfMessage\nBot => ${target}: ${toSend}`);
   });
 }
 
@@ -61,9 +61,9 @@ export function logPrivateMessage(client: IIrcClient) {
   client.on('message', (from, to, message) => {
     if (to === client.nick) {
       if (IsStatResponse(message)) {
-        pmLogger.trace(`@IIrcClient#logPrivateMessage:@NodeIRC#message\nPM: ${from} -> ${message}`);
+        pmLogger.trace(`@NodeIRC#message\nPM: ${from} -> ${message}`);
       } else {
-        pmLogger.info(`@IIrcClient#logPrivateMessage:@NodeIRC#message\nPM: ${from} -> ${message}`);
+        pmLogger.info(`@NodeIRC#message\nPM: ${from} -> ${message}`);
       }
     }
   });

--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -26,34 +26,34 @@ export function logIrcEvent(client: IIrcClient) {
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;
-    ircLogger.debug(`@NodeIRC#registered\n${args?.join(', ')}`);
+    ircLogger.debug(`@NodeIRC#registered ${args?.join(', ')}`);
   });
   client.on('message', function (from, to, message) {
-    ircLogger.debug(`@NodeIRC#message\n${from} => ${to}: ${message}`);
+    ircLogger.debug(`@NodeIRC#message ${from} => ${to}: ${message}`);
   });
   client.on('pm', function (nick, message) {
-    ircLogger.debug(`@NodeIRC#pm\n${nick}: ${message}`);
+    ircLogger.debug(`@NodeIRC#pm ${nick}: ${message}`);
   });
   client.on('join', function (channel, who) {
-    ircLogger.debug(`@NodeIRC#join\n${who} has joined ${channel}`);
+    ircLogger.debug(`@NodeIRC#join ${who} has joined ${channel}`);
   });
   client.on('part', function (channel, who, reason) {
-    ircLogger.debug(`@NodeIRC#part\n${who} has left ${channel}: ${reason}`);
+    ircLogger.debug(`@NodeIRC#part ${who} has left ${channel}: ${reason}`);
   });
   client.on('kick', function (channel, who, by, reason) {
-    ircLogger.debug(`@NodeIRC#kick\n${who} was kicked from ${channel} by ${by}: ${reason}`);
+    ircLogger.debug(`@NodeIRC#kick ${who} was kicked from ${channel} by ${by}: ${reason}`);
   });
   client.on('invite', (channel, from) => {
-    ircLogger.debug(`@NodeIRC#invite\n${from} invited you to ${channel}`);
+    ircLogger.debug(`@NodeIRC#invite ${from} invited you to ${channel}`);
   });
   client.on('notice', function (from, to, message) {
-    ircLogger.debug(`@NodeIRC#notice\n${from} => ${to}: ${message}`);
+    ircLogger.debug(`@NodeIRC#notice ${from} => ${to}: ${message}`);
   });
   client.on('action', function (from, to, text, message) {
-    ircLogger.debug(`@NodeIRC#action\n${from} => ${to}: ${text}`);
+    ircLogger.debug(`@NodeIRC#action ${from} => ${to}: ${text}`);
   });
   client.on('selfMessage', (target: string, toSend) => {
-    ircLogger.debug(`@NodeIRC#selfMessage\nBot => ${target}: ${toSend}`);
+    ircLogger.debug(`@NodeIRC#selfMessage Bot => ${target}: ${toSend}`);
   });
 }
 
@@ -61,9 +61,9 @@ export function logPrivateMessage(client: IIrcClient) {
   client.on('message', (from, to, message) => {
     if (to === client.nick) {
       if (IsStatResponse(message)) {
-        pmLogger.trace(`@NodeIRC#message\nPM: ${from} -> ${message}`);
+        pmLogger.trace(`@NodeIRC#message PM: ${from} -> ${message}`);
       } else {
-        pmLogger.info(`@NodeIRC#message\nPM: ${from} -> ${message}`);
+        pmLogger.info(`@NodeIRC#message PM: ${from} -> ${message}`);
       }
     }
   });

--- a/src/IIrcClient.ts
+++ b/src/IIrcClient.ts
@@ -22,7 +22,7 @@ export interface IIrcClient extends EventEmitter {
 
 export function logIrcEvent(client: IIrcClient) {
   client.on('error', function (message) {
-    ircLogger.error(`@NodeIRC#error\n${message instanceof Error ? `${message.name}\n${message.stack}\n` : ''}${message instanceof Object && JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
+    ircLogger.error(`@NodeIRC#error\n${message instanceof Error ? `${message.message}\n${message.stack}\n` : ''}${message instanceof Object && JSON.stringify(message) !== '{}' ? `${JSON.stringify(message, null, 2)}\n` : ''}message =`, message);
   });
   client.on('registered', function (message) {
     const args = message.args as string[] | undefined;


### PR DESCRIPTION
**Description**
#90 for `IIrcClient` file.

```ts
// IIrcClient error demo
enter 1
[00:31:34.165][INFO] ahr - Entering a lobby... Channel : #mp_1
[00:31:35.345][ERROR] irc - @NodeIRC#error
// error.message here
// error.stack here
// a beautiful message object in JSON format with an indention of 2
{
  "prefix": "cho.ppy.sh",
  "server": "cho.ppy.sh",
  "command": "err_nosuchchannel",
  "rawCommand": "403",
  "commandType": "error",
  "args": [
    "MyUsername",
    "#mp_1",
    "No such channel #mp_1"
  ]
}
// the raw message object, this will be explicitly shown no matter what
message = {
  prefix: 'cho.ppy.sh',
  server: 'cho.ppy.sh',
  command: 'err_nosuchchannel',
  rawCommand: '403',
  commandType: 'error',
  args: [ 'MyUsername', '#mp_1', 'No such channel #mp_1' ]
}
```

Please request the desired changes if something did not fit well or can still be improved.